### PR TITLE
Added small changes to allow for unbalanced panels with 'panel = F'

### DIFF
--- a/R/att_gt.R
+++ b/R/att_gt.R
@@ -167,12 +167,6 @@ att_gt <- function(yname,
   tt <- attgt.results$tt
   inffunc1 <- attgt.results$inf.func
 
-  # drop anywhere where ATT is NA because of unbalanced panel
-  notna <- !is.na(att)
-  group <- group[notna]
-  att <- att[notna]
-  tt <- tt[notna]
-  inffunc1 <- inffunc1[, notna]
 
 
   # estimate variance
@@ -194,7 +188,7 @@ att_gt <- function(yname,
 
     bout <- mboot(inffunc1, DIDparams=dp)
     bres <- bout$bres
-    V <- bout$V
+    V[!is.na(V)] <- bout$V
   }
 
 
@@ -217,7 +211,11 @@ att_gt <- function(yname,
     message("No pre-treatment periods to test")
     W  <- NULL
     Wpval <- NULL
-  } else if (det(preV) == 0) {
+  } else if(sum(is.na(preV))) {
+      warning("Not returning pre-test Wald statistic due to NA pre-treatment values")
+      W <- NULL
+      Wpval <- NULL
+    } else if (det(preV) == 0) {
     # singluar covariance matrix for pre-treatment periods
     warning("Not returning pre-test Wald statistic due to singular covariance matrix")
     W <- NULL

--- a/R/att_gt.R
+++ b/R/att_gt.R
@@ -167,6 +167,13 @@ att_gt <- function(yname,
   tt <- attgt.results$tt
   inffunc1 <- attgt.results$inf.func
 
+  # drop anywhere where ATT is NA because of unbalanced panel
+  notna <- !is.na(att)
+  group <- group[notna]
+  att <- att[notna]
+  tt <- tt[notna]
+  inffunc1 <- inffunc1[, notna]
+
 
   # estimate variance
   # this is analogous to cluster robust standard errors that

--- a/R/mboot.R
+++ b/R/mboot.R
@@ -71,7 +71,7 @@ mboot <- function(inf.func, DIDparams) {
   ifelse(class(bres)=="matrix", bres <- t(bres), bres <- as.matrix(bres))
   # Non-degenerate dimensions
   ndg.dim <- base::colSums(bres)!=0
-  bres <- bres[ , ndg.dim]
+  bres <- bres[ , ndg.dim, drop = F]
 
   # bootstrap variance matrix (this matrix can be defective because of degenerate cases)
   V <- cov(bres)

--- a/R/pre_process_did.R
+++ b/R/pre_process_did.R
@@ -192,6 +192,9 @@ pre_process_did <- function(yname,
     if(is.null(idname)) {
       data$rowid <- seq(1:nrow(data))
       idname <- "rowid"
+    } else {
+      # set rowid to idname for repeated cross section/unbalance panel
+      data$rowid <- data[, idname]
     }
     n <- nrow(data)
   }


### PR DESCRIPTION
I was trying to run this for an unbalanced panel with `panel = FALSE` and ran into a few errors:

- Setting `panel = FALSE` uses the `rowid` column in the temporary dataframe in `compute.att_gt`, but `rowid` is only created if `idname` is `NULL`. I added an else case to deal with that
- For an unbalance panel the `att` vector has `NA` elements for the pre-periods where there is no data, so I dropped these in `att_gt`
- When the bootstrap results are a vector, the covariance matrix can't be created, so I added `drop = FALSE` 