### PR TITLE
Improved ggdid functionality, look, docs.

### DIFF
--- a/R/gplot.R
+++ b/R/gplot.R
@@ -12,7 +12,7 @@
 #'
 #' @export
 gplot <- function(ssresults, ylim=NULL, xlab=NULL, ylab=NULL, title="Group", xgap=1,
-                  legend=TRUE) {
+                  legend=TRUE, ref_line = 0, theming = TRUE) {
   dabreaks <- ssresults$year[seq(1, length(ssresults$year), xgap)]
 
   c.point <-  qnorm(1 - ssresults$alp/2)
@@ -20,25 +20,31 @@ gplot <- function(ssresults, ylim=NULL, xlab=NULL, ylab=NULL, title="Group", xga
   p <- ggplot(ssresults,
               aes(x=as.numeric(year), y=att, ymin=(att-c*att.se),
                   ymax=(att+c*att.se))) +
-    
+
     geom_point(aes(colour=post), size=1.5) +
-    #geom_ribbon(aes(x=as.numeric(year)), alpha=0.2) + 
-    geom_errorbar(aes(colour=post), width=0.1) +   
+    #geom_ribbon(aes(x=as.numeric(year)), alpha=0.2) +
+    geom_errorbar(aes(colour=post), width=0.1) +
     scale_y_continuous(limits=ylim) +
     #scale_x_discrete(breaks=dabreaks, labels=as.character(dabreaks)) +
-    scale_x_continuous(breaks=as.numeric(dabreaks), labels=as.character(dabreaks)) + 
-    scale_colour_hue(drop=FALSE) +
-    ylab("") +
-    xlab("") +
-    ggtitle(paste(title, unique(ssresults$group))) +
-    theme_bw() +
-    theme(plot.title = element_text(color="darkgray", face="bold", size=12)) +
-    theme(axis.title = element_text(color="darkgray", face="bold", size=12))
+    scale_x_continuous(breaks=as.numeric(dabreaks), labels=as.character(dabreaks)) +
+    scale_colour_hue(drop=FALSE, labels = c('Pre','Post')) +
+    labs(x = xlab, y = ylab, title = title, color = NULL)
 
+  if (!is.null(ref_line)) {
+    p <- p + geom_hline(aes(yintercept = ref_line), linetype = 'dashed')
+  }
+  if (theming) {
+    p <- p + ggpubr::theme_pubr() +
+      theme(plot.title = element_text(color="darkgray", face="bold", size=12),
+            axis.title = element_text(color="darkgray", face="bold", size=12),
+            strip.background = element_rect(fill = 'white', color = 'white'),
+            strip.text = element_text(color = 'darkgray', face = 'bold', size = 12, hjust = 0),
+            legend.position = 'bottom')
+  }
   if (!legend) {
     p  <- p + ggpubr::rremove("legend")
   }
-  
+
   p
 }
 
@@ -57,36 +63,46 @@ gplot <- function(ssresults, ylim=NULL, xlab=NULL, ylab=NULL, title="Group", xga
 #'
 #' @export
 splot <- function(ssresults, ylim=NULL, xlab=NULL, ylab=NULL, title="Group",
-                  legend=TRUE) {
+                  legend=TRUE, ref_line = 0, theming = TRUE) {
 
   # names of variables are "weird" for this function because this code builds
   # on the same infrastructure as for plotting group-time average treatment
   # effects and aggregations using event time or calendar time
 
   # the group variable is saved in year
-  
+
+  if (is.null(xlab)) {
+    xlab <- 'ATT'
+  }
+  if (is.null(ylab)) {
+    ylab <- 'Group'
+  }
+
   p <- ggplot(ssresults,
               aes(y=as.factor(year), x=att, xmin=(att-c*att.se),
-                  xmax=(att+c*att.se))) +    
+                  xmax=(att+c*att.se))) +
     geom_point(aes(colour=post), size=1.5) +
-    #geom_ribbon(aes(x=as.numeric(year)), alpha=0.2) + 
-    geom_errorbarh(aes(colour=post), height=0.1)  +   
+    #geom_ribbon(aes(x=as.numeric(year)), alpha=0.2) +
+    geom_errorbarh(aes(colour=post), height=0.1)  +
     scale_y_discrete(breaks=as.factor(ssresults$year)) +
     #scale_x_discrete(breaks=dabreaks, labels=as.character(dabreaks)) +
-    scale_x_continuous(limits=ylim) + 
+    scale_x_continuous(limits=ylim) +
     scale_colour_hue(drop=FALSE) +
-    ylab("group") +
-    xlab("att") +
-    ggtitle(paste(title, unique(ssresults$group))) +
-    theme_bw() +
-    theme(plot.title = element_text(color="darkgray", face="bold", size=8)) +
-    theme(axis.title = element_text(color="darkgray", face="bold", size=8)) +
-    theme(legend.position="none")
+    labs(x = xlab, y = ylab, title = title)
 
-  
+  if (!is.null(ref_line)) {
+    p <- p + geom_vline(aes(xintercept = ref_line), linetype = 'dashed')
+  }
+  if (theming) {
+    p <- p + ggpubr::theme_pubr() +
+      theme(plot.title = element_text(color="darkgray", face="bold", size=12),
+            axis.title = element_text(color="darkgray", face="bold", size=12),
+            legend.position = 'none')
+  }
+
   if (!legend) {
     p  <- p + ggpubr::rremove("legend")
   }
-  
+
   p
 }


### PR DESCRIPTION
This PR improves `ggdid` functionality and look. Here are what the default graphs look like, using the example model (obviously the height/width is set by user). All can now be themed after the fact as well by the user, theming can be turned off, and there's a setting for where the dashed line goes and how the groups are titled in `ggdid.MP`. Also the `xlab` and `ylab` options work now, they didn't before. LMK any changes to the defaults you'd like, this is all easy to change:

`ggdid.MP`
![image](https://user-images.githubusercontent.com/44816781/115538854-29aa2800-a251-11eb-89fb-9adea0d3f91f.png)

`ggdid.AGGTEobj` with `type = 'dynamic'` or `type = 'calendar'`
![image](https://user-images.githubusercontent.com/44816781/115538571-e2bc3280-a250-11eb-810f-682def9b3023.png)

`ggdid.AGGTEobj` with `type = 'group'`
![image](https://user-images.githubusercontent.com/44816781/115539780-3da25980-a252-11eb-8c15-7b7c1cf06d07.png)
