### PR TITLE
Fix calendar effects plotting wrong label and color

### DIFF
--- a/R/gplot.R
+++ b/R/gplot.R
@@ -27,7 +27,7 @@ gplot <- function(ssresults, ylim=NULL, xlab=NULL, ylab=NULL, title="Group", xga
     scale_y_continuous(limits=ylim) +
     #scale_x_discrete(breaks=dabreaks, labels=as.character(dabreaks)) +
     scale_x_continuous(breaks=as.numeric(dabreaks), labels=as.character(dabreaks)) +
-    scale_colour_hue(drop=FALSE, labels = c('Pre','Post')) +
+    scale_color_manual(drop=FALSE, values=c("#e87d72","#56bcc2"), breaks = c(0, 1), labels = c('Pre','Post')) +
     labs(x = xlab, y = ylab, title = title, color = NULL)
 
   if (!is.null(ref_line)) {
@@ -87,7 +87,7 @@ splot <- function(ssresults, ylim=NULL, xlab=NULL, ylab=NULL, title="Group",
     scale_y_discrete(breaks=as.factor(ssresults$year)) +
     #scale_x_discrete(breaks=dabreaks, labels=as.character(dabreaks)) +
     scale_x_continuous(limits=ylim) +
-    scale_colour_hue(drop=FALSE) +
+    scale_color_manual(drop=FALSE, values=c("#e87d72","#56bcc2"), breaks = c(0, 1), labels = c('Pre','Post')) +
     labs(x = xlab, y = ylab, title = title)
 
   if (!is.null(ref_line)) {


### PR DESCRIPTION
Just a small fix. Currently the color scale is coded as

	scale_colour_hue(drop=FALSE, labels = c('Pre','Post')) +

This creates a problem for plotting calendar effects and group effects in that it defaults to the color red and for calendar effects labels them as 'Pre'. 

	scale_color_manual(drop=FALSE, values=c("#e87d72","#56bcc2"), breaks = c(0, 1), labels = c('Pre','Post')) +


*Example of problem:*

This makes it explicit that post = 0 maps to Pre and the red color and 1 maps to Post and the blue color

    library(tidyverse)
    library(did)
    data(mpdta)

    out <- att_gt(yname = "lemp",
                  gname = "first.treat",
                  idname = "countyreal",
                  tname = "year",
                  xformla = ~1,
                  data = mpdta,
                  est_method = "reg"
    )

    ggdid(aggte(out, type="dynamic"))

![](https://i.imgur.com/TdWwH0I.png)

    ggdid(aggte(out, type="calendar"))

![](https://i.imgur.com/vyQiP1U.png)

    ggdid(aggte(out, type="group"))

![](https://i.imgur.com/OPt34mg.png)


*After changes*
![image](https://user-images.githubusercontent.com/19961439/116759335-512a8e80-a9cf-11eb-9214-8fe7c5525e22.png)

![image](https://user-images.githubusercontent.com/19961439/116759321-4a038080-a9cf-11eb-92a2-1877788d4a55.png)


