### PR TITLE
Fail loudly when `type` is misspecified

### DIFF
--- a/R/compute.aggte.R
+++ b/R/compute.aggte.R
@@ -69,6 +69,9 @@ compute.aggte <- function(MP,
   MP$DIDparams$cband <- cband
   dp <- MP$DIDparams
 
+  if(!(type %in% c("simple", "dynamic", "group", "calendar"))) {
+    stop('`type` must be one of c("simple", "dynamic", "group", "calendar")')
+  }
 
   if(na.rm){
     notna <- !is.na(att)


### PR DESCRIPTION
The below code doesn't give any warning or indication of failure. Instead silently returning `NULL`

```r
library(did)
data(mpdta)
out <- att_gt(yname="lemp",
              tname="year",
              idname="countyreal",
              gname="first.treat",
              xformla=NULL,
              data=mpdta)

aggte(out, type = "simpl")
```

<sup>Created on 2022-03-29 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>