### PR TITLE
Paralellized `mboot`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Imports:
     generics,
     tidyr
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.0
 VignetteBuilder: knitr
 Suggests: 
     rmarkdown,

--- a/R/att_gt.R
+++ b/R/att_gt.R
@@ -38,9 +38,7 @@
 #' @param print_details Whether or not to show details/progress of computations.
 #'   Default is `FALSE`.
 #' @param pl Whether or not to use parallel processing
-#'  (not implemented yet)
 #' @param cores The number of cores to use for parallel processing
-#'  (not implemented yet)
 #' @param est_method the method to compute group-time average treatment effects.  The default is "dr" which uses the doubly robust
 #' approach in the `DRDID` package.  Other built-in methods
 #' include "ipw" for inverse probability weighting and "reg" for
@@ -258,7 +256,7 @@ att_gt <- function(yname,
   # bootstrap variance matrix
   if (bstrap) {
 
-    bout <- mboot(inffunc, DIDparams=dp)
+    bout <- mboot(inffunc, DIDparams=dp, pl=pl, cores=cores)
     bres <- bout$bres
     
     if(length(zero_na_sd_entry)>0) {

--- a/R/mboot.R
+++ b/R/mboot.R
@@ -14,7 +14,7 @@
 #' \item{crit.val}{a critical value for computing uniform confidence bands}
 #'
 #' @export
-mboot <- function(inf.func, DIDparams) {
+mboot <- function(inf.func, DIDparams, pl = FALSE, cores = 1) {
 
   # setup needed variables
   data <- as.data.frame(DIDparams$data)
@@ -76,13 +76,13 @@ mboot <- function(inf.func, DIDparams) {
   # multiplier bootstrap
   n_clusters <- n
   if (length(clustervars)==0) {
-    bres <- sqrt(n)*BMisc::multiplier_bootstrap(inf.func, biters)
+    bres <- sqrt(n) * run_multiplier_bootstrap(inf.func, biters, pl, cores)
   } else {
     n_clusters <- length(unique(data[,clustervars]))
     cluster <- unique(dta[,c(idname,clustervars)])[,2]
     cluster_n <- aggregate(cluster, by=list(cluster), length)[,2]
     cluster_mean_if <- rowsum(inf.func, cluster,reorder=TRUE) / cluster_n
-    bres <- sqrt(n_clusters)*BMisc::multiplier_bootstrap(cluster_mean_if, biters)
+    bres <- sqrt(n_clusters) * run_multiplier_bootstrap(cluster_mean_if, biters, pl, cores) 
   }
 
 
@@ -116,4 +116,27 @@ mboot <- function(inf.func, DIDparams) {
   #se[se==0] <- NA
 
   list(bres = bres, V = V, se = se, crit.val = crit.val)
+}
+
+run_multiplier_bootstrap <- function(inf.func, biters, pl = FALSE, cores = 1) {
+  ngroups = ceiling(biters/cores)
+  chunks = rep(ngroups, cores)
+  # Round down so you end up with the right number of biters
+  chunks[1] = chunks[1] + biters - sum(chunks)
+
+  n <- nrow(inf.func)
+  parallel.function <- function(biters) {
+    BMisc::multiplier_bootstrap(inf.func, biters)
+  }
+  # From tests, this is about where it becomes worth it to parallelize
+  if(n > 2500 & pl == TRUE & cores > 1) {
+    results = parallel::mclapply(
+      chunks, 
+      FUN = parallel.function
+    )
+    results = do.call(rbind, results)
+  } else {
+    results = BMisc::multiplier_bootstrap(inf.func, biters)
+  }
+  return(results)
 }

--- a/man/DIDparams.Rd
+++ b/man/DIDparams.Rd
@@ -100,11 +100,9 @@ bands, \code{bstrap} must also be set to \code{TRUE}.  The default is
 \item{print_details}{Whether or not to show details/progress of computations.
 Default is \code{FALSE}.}
 
-\item{pl}{Whether or not to use parallel processing
-(not implemented yet)}
+\item{pl}{Whether or not to use parallel processing}
 
-\item{cores}{The number of cores to use for parallel processing
-(not implemented yet)}
+\item{cores}{The number of cores to use for parallel processing}
 
 \item{est_method}{the method to compute group-time average treatment effects.  The default is "dr" which uses the doubly robust
 approach in the \code{DRDID} package.  Other built-in methods

--- a/man/aggte.Rd
+++ b/man/aggte.Rd
@@ -86,7 +86,9 @@ and "calendar."
 \section{Examples}{
 
 
-Initial ATT(g,t) estimates from \code{\link[=att_gt]{att_gt()}}\if{html}{\out{<div class="sourceCode r">}}\preformatted{data(mpdta)
+Initial ATT(g,t) estimates from \code{\link[=att_gt]{att_gt()}}
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{data(mpdta)
 out <- att_gt(yname="lemp",
                tname="year",
                idname="countyreal",
@@ -97,7 +99,9 @@ out <- att_gt(yname="lemp",
 
 You can aggregate the ATT(g,t) in many ways.
 
-\strong{Overall ATT:}\if{html}{\out{<div class="sourceCode r">}}\preformatted{aggte(out, type = "simple")
+\strong{Overall ATT:}
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{aggte(out, type = "simple")
 #> 
 #> Call:
 #> aggte(MP = out, type = "simple")
@@ -106,7 +110,7 @@ You can aggregate the ATT(g,t) in many ways.
 #> 
 #> 
 #>    ATT    Std. Error     [ 95\%  Conf. Int.]  
-#>  -0.04        0.0119    -0.0633     -0.0166 *
+#>  -0.04        0.0131    -0.0656     -0.0143 *
 #> 
 #> 
 #> ---
@@ -116,7 +120,9 @@ You can aggregate the ATT(g,t) in many ways.
 #> Estimation Method:  Doubly Robust
 }\if{html}{\out{</div>}}
 
-\strong{Dynamic ATT (Event-Study):}\if{html}{\out{<div class="sourceCode r">}}\preformatted{aggte(out, type = "dynamic")
+\strong{Dynamic ATT (Event-Study):}
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{aggte(out, type = "dynamic")
 #> 
 #> Call:
 #> aggte(MP = out, type = "dynamic")
@@ -126,18 +132,18 @@ You can aggregate the ATT(g,t) in many ways.
 #> 
 #> Overall summary of ATT's based on event-study/dynamic aggregation:  
 #>      ATT    Std. Error     [ 95\%  Conf. Int.]  
-#>  -0.0772        0.0211    -0.1185      -0.036 *
+#>  -0.0772        0.0191    -0.1147     -0.0398 *
 #> 
 #> 
 #> Dynamic Effects:
 #>  Event time Estimate Std. Error [95\% Simult.  Conf. Band]  
-#>          -3   0.0305     0.0141       -0.0038      0.0649  
-#>          -2  -0.0006     0.0129       -0.0320      0.0309  
-#>          -1  -0.0245     0.0144       -0.0596      0.0107  
-#>           0  -0.0199     0.0120       -0.0491      0.0092  
-#>           1  -0.0510     0.0179       -0.0947     -0.0073 *
-#>           2  -0.1373     0.0407       -0.2363     -0.0382 *
-#>           3  -0.1008     0.0363       -0.1892     -0.0125 *
+#>          -3   0.0305     0.0150       -0.0090      0.0700  
+#>          -2  -0.0006     0.0139       -0.0371      0.0360  
+#>          -1  -0.0245     0.0142       -0.0619      0.0130  
+#>           0  -0.0199     0.0119       -0.0511      0.0112  
+#>           1  -0.0510     0.0169       -0.0953     -0.0066 *
+#>           2  -0.1373     0.0405       -0.2437     -0.0308 *
+#>           3  -0.1008     0.0356       -0.1945     -0.0071 *
 #> ---
 #> Signif. codes: `*' confidence band does not cover 0
 #> 
@@ -145,7 +151,9 @@ You can aggregate the ATT(g,t) in many ways.
 #> Estimation Method:  Doubly Robust
 }\if{html}{\out{</div>}}
 
-\strong{ATT for each group:}\if{html}{\out{<div class="sourceCode r">}}\preformatted{aggte(out, type = "group")
+\strong{ATT for each group:}
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{aggte(out, type = "group")
 #> 
 #> Call:
 #> aggte(MP = out, type = "group")
@@ -155,14 +163,14 @@ You can aggregate the ATT(g,t) in many ways.
 #> 
 #> Overall summary of ATT's based on group/cohort aggregation:  
 #>     ATT    Std. Error     [ 95\%  Conf. Int.]  
-#>  -0.031        0.0126    -0.0557     -0.0063 *
+#>  -0.031        0.0128     -0.056      -0.006 *
 #> 
 #> 
 #> Group Effects:
 #>  Group Estimate Std. Error [95\% Simult.  Conf. Band]  
-#>   2004  -0.0797     0.0283       -0.1460     -0.0135 *
-#>   2006  -0.0229     0.0184       -0.0660      0.0202  
-#>   2007  -0.0261     0.0181       -0.0685      0.0163  
+#>   2004  -0.0797     0.0286       -0.1467     -0.0128 *
+#>   2006  -0.0229     0.0169       -0.0624      0.0166  
+#>   2007  -0.0261     0.0168       -0.0653      0.0132  
 #> ---
 #> Signif. codes: `*' confidence band does not cover 0
 #> 
@@ -170,7 +178,9 @@ You can aggregate the ATT(g,t) in many ways.
 #> Estimation Method:  Doubly Robust
 }\if{html}{\out{</div>}}
 
-\strong{ATT for each calendar year:}\if{html}{\out{<div class="sourceCode r">}}\preformatted{aggte(out, type = "calendar")
+\strong{ATT for each calendar year:}
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{aggte(out, type = "calendar")
 #> 
 #> Call:
 #> aggte(MP = out, type = "calendar")
@@ -180,15 +190,15 @@ You can aggregate the ATT(g,t) in many ways.
 #> 
 #> Overall summary of ATT's based on calendar time aggregation:  
 #>      ATT    Std. Error     [ 95\%  Conf. Int.]  
-#>  -0.0417        0.0177    -0.0765     -0.0069 *
+#>  -0.0417        0.0168    -0.0747     -0.0087 *
 #> 
 #> 
 #> Time Effects:
 #>  Time Estimate Std. Error [95\% Simult.  Conf. Band]  
-#>  2004  -0.0105     0.0242       -0.0679      0.0469  
-#>  2005  -0.0704     0.0308       -0.1434      0.0026  
-#>  2006  -0.0488     0.0204       -0.0971     -0.0005 *
-#>  2007  -0.0371     0.0148       -0.0720     -0.0021 *
+#>  2004  -0.0105     0.0255       -0.0700      0.0490  
+#>  2005  -0.0704     0.0326       -0.1463      0.0055  
+#>  2006  -0.0488     0.0207       -0.0971     -0.0005 *
+#>  2007  -0.0371     0.0135       -0.0684     -0.0057 *
 #> ---
 #> Signif. codes: `*' confidence band does not cover 0
 #> 

--- a/man/att_gt.Rd
+++ b/man/att_gt.Rd
@@ -153,11 +153,9 @@ extra estimate in an earlier period.}
 \item{print_details}{Whether or not to show details/progress of computations.
 Default is \code{FALSE}.}
 
-\item{pl}{Whether or not to use parallel processing
-(not implemented yet)}
+\item{pl}{Whether or not to use parallel processing}
 
-\item{cores}{The number of cores to use for parallel processing
-(not implemented yet)}
+\item{cores}{The number of cores to use for parallel processing}
 }
 \value{
 an \code{\link{MP}} object containing all the results for group-time average
@@ -171,7 +169,9 @@ treatment effect heterogeneity and dynamics.
 See Callaway and Sant'Anna (2021) for a detailed description.
 }
 \section{Examples:}{
-\strong{Basic \code{\link[=att_gt]{att_gt()}} call:}\if{html}{\out{<div class="sourceCode r">}}\preformatted{# Example data
+\strong{Basic \code{\link[=att_gt]{att_gt()}} call:}
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{# Example data
 data(mpdta)
 
 out1 <- att_gt(yname="lemp",
@@ -190,18 +190,18 @@ summary(out1)
 #> 
 #> Group-Time Average Treatment Effects:
 #>  Group Time ATT(g,t) Std. Error [95\% Simult.  Conf. Band]  
-#>   2004 2004  -0.0105     0.0253       -0.0784      0.0574  
-#>   2004 2005  -0.0704     0.0321       -0.1565      0.0157  
-#>   2004 2006  -0.1373     0.0370       -0.2365     -0.0380 *
-#>   2004 2007  -0.1008     0.0346       -0.1937     -0.0079 *
-#>   2006 2004   0.0065     0.0225       -0.0539      0.0669  
-#>   2006 2005  -0.0028     0.0213       -0.0598      0.0543  
-#>   2006 2006  -0.0046     0.0171       -0.0504      0.0413  
-#>   2006 2007  -0.0412     0.0208       -0.0970      0.0145  
-#>   2007 2004   0.0305     0.0155       -0.0110      0.0720  
-#>   2007 2005  -0.0027     0.0163       -0.0464      0.0409  
-#>   2007 2006  -0.0311     0.0168       -0.0762      0.0140  
-#>   2007 2007  -0.0261     0.0172       -0.0721      0.0200  
+#>   2004 2004  -0.0105     0.0240       -0.0779      0.0569  
+#>   2004 2005  -0.0704     0.0316       -0.1592      0.0183  
+#>   2004 2006  -0.1373     0.0383       -0.2448     -0.0297 *
+#>   2004 2007  -0.1008     0.0342       -0.1969     -0.0048 *
+#>   2006 2004   0.0065     0.0226       -0.0571      0.0701  
+#>   2006 2005  -0.0028     0.0201       -0.0594      0.0539  
+#>   2006 2006  -0.0046     0.0181       -0.0556      0.0464  
+#>   2006 2007  -0.0412     0.0192       -0.0953      0.0128  
+#>   2007 2004   0.0305     0.0147       -0.0109      0.0719  
+#>   2007 2005  -0.0027     0.0160       -0.0476      0.0422  
+#>   2007 2006  -0.0311     0.0179       -0.0814      0.0192  
+#>   2007 2007  -0.0261     0.0165       -0.0724      0.0203  
 #> ---
 #> Signif. codes: `*' confidence band does not cover 0
 #> 
@@ -210,7 +210,9 @@ summary(out1)
 #> Estimation Method:  Doubly Robust
 }\if{html}{\out{</div>}}
 
-\strong{Using covariates:}\if{html}{\out{<div class="sourceCode r">}}\preformatted{out2 <- att_gt(yname="lemp",
+\strong{Using covariates:}
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{out2 <- att_gt(yname="lemp",
                tname="year",
                idname="countyreal",
                gname="first.treat",
@@ -226,18 +228,18 @@ summary(out2)
 #> 
 #> Group-Time Average Treatment Effects:
 #>  Group Time ATT(g,t) Std. Error [95\% Simult.  Conf. Band]  
-#>   2004 2004  -0.0145     0.0226       -0.0745      0.0454  
-#>   2004 2005  -0.0764     0.0280       -0.1507     -0.0021 *
-#>   2004 2006  -0.1404     0.0347       -0.2325     -0.0484 *
-#>   2004 2007  -0.1069     0.0347       -0.1991     -0.0147 *
-#>   2006 2004  -0.0005     0.0223       -0.0596      0.0587  
-#>   2006 2005  -0.0062     0.0198       -0.0586      0.0462  
-#>   2006 2006   0.0010     0.0193       -0.0503      0.0522  
-#>   2006 2007  -0.0413     0.0213       -0.0978      0.0152  
-#>   2007 2004   0.0267     0.0143       -0.0113      0.0648  
-#>   2007 2005  -0.0046     0.0159       -0.0469      0.0378  
-#>   2007 2006  -0.0284     0.0187       -0.0780      0.0211  
-#>   2007 2007  -0.0288     0.0172       -0.0744      0.0169  
+#>   2004 2004  -0.0145     0.0218       -0.0728      0.0437  
+#>   2004 2005  -0.0764     0.0291       -0.1543      0.0015  
+#>   2004 2006  -0.1404     0.0370       -0.2395     -0.0414 *
+#>   2004 2007  -0.1069     0.0354       -0.2015     -0.0123 *
+#>   2006 2004  -0.0005     0.0232       -0.0625      0.0615  
+#>   2006 2005  -0.0062     0.0192       -0.0575      0.0451  
+#>   2006 2006   0.0010     0.0204       -0.0537      0.0556  
+#>   2006 2007  -0.0413     0.0210       -0.0974      0.0148  
+#>   2007 2004   0.0267     0.0139       -0.0104      0.0639  
+#>   2007 2005  -0.0046     0.0157       -0.0466      0.0375  
+#>   2007 2006  -0.0284     0.0176       -0.0755      0.0186  
+#>   2007 2007  -0.0288     0.0179       -0.0767      0.0192  
 #> ---
 #> Signif. codes: `*' confidence band does not cover 0
 #> 
@@ -246,7 +248,9 @@ summary(out2)
 #> Estimation Method:  Doubly Robust
 }\if{html}{\out{</div>}}
 
-\strong{Specify comparison units:}\if{html}{\out{<div class="sourceCode r">}}\preformatted{out3 <- att_gt(yname="lemp",
+\strong{Specify comparison units:}
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{out3 <- att_gt(yname="lemp",
                tname="year",
                idname="countyreal",
                gname="first.treat",
@@ -263,18 +267,18 @@ summary(out3)
 #> 
 #> Group-Time Average Treatment Effects:
 #>  Group Time ATT(g,t) Std. Error [95\% Simult.  Conf. Band]  
-#>   2004 2004  -0.0212     0.0227       -0.0805      0.0382  
-#>   2004 2005  -0.0816     0.0296       -0.1590     -0.0042 *
-#>   2004 2006  -0.1382     0.0374       -0.2361     -0.0403 *
-#>   2004 2007  -0.1069     0.0354       -0.1995     -0.0143 *
-#>   2006 2004  -0.0075     0.0225       -0.0663      0.0514  
-#>   2006 2005  -0.0046     0.0189       -0.0541      0.0450  
-#>   2006 2006   0.0087     0.0161       -0.0336      0.0509  
-#>   2006 2007  -0.0413     0.0203       -0.0943      0.0118  
-#>   2007 2004   0.0269     0.0145       -0.0111      0.0649  
-#>   2007 2005  -0.0042     0.0151       -0.0438      0.0354  
-#>   2007 2006  -0.0284     0.0183       -0.0763      0.0194  
-#>   2007 2007  -0.0288     0.0155       -0.0694      0.0119  
+#>   2004 2004  -0.0212     0.0219       -0.0776      0.0353  
+#>   2004 2005  -0.0816     0.0281       -0.1541     -0.0091 *
+#>   2004 2006  -0.1382     0.0363       -0.2320     -0.0444 *
+#>   2004 2007  -0.1069     0.0331       -0.1923     -0.0215 *
+#>   2006 2004  -0.0075     0.0232       -0.0674      0.0525  
+#>   2006 2005  -0.0046     0.0191       -0.0538      0.0447  
+#>   2006 2006   0.0087     0.0163       -0.0335      0.0508  
+#>   2006 2007  -0.0413     0.0200       -0.0928      0.0102  
+#>   2007 2004   0.0269     0.0136       -0.0082      0.0621  
+#>   2007 2005  -0.0042     0.0168       -0.0475      0.0391  
+#>   2007 2006  -0.0284     0.0184       -0.0759      0.0190  
+#>   2007 2007  -0.0288     0.0172       -0.0733      0.0157  
 #> ---
 #> Signif. codes: `*' confidence band does not cover 0
 #> 

--- a/man/conditional_did_pretest.Rd
+++ b/man/conditional_did_pretest.Rd
@@ -122,11 +122,9 @@ if covariates are included.}
 \item{print_details}{Whether or not to show details/progress of computations.
 Default is \code{FALSE}.}
 
-\item{pl}{Whether or not to use parallel processing
-(not implemented yet)}
+\item{pl}{Whether or not to use parallel processing}
 
-\item{cores}{The number of cores to use for parallel processing
-(not implemented yet)}
+\item{cores}{The number of cores to use for parallel processing}
 }
 \value{
 an \code{\link{MP.TEST}} object

--- a/man/honest_did.AGGTEobj.Rd
+++ b/man/honest_did.AGGTEobj.Rd
@@ -42,7 +42,7 @@ of deviations from parallel trends in pre-treatment periods).}
   }
 
 \item{Mvec}{
-  Vector of M values for which the user wishes to construct robust confidence intervals. If NULL, the function constructs a grid of length 10 that starts at M = 0 and ends at M equal to the upper bound constructed from the pre-periods using the function DeltaSD_upperBound_Mpre if number of pre-periods > 1 or the standard deviation of the first post-period coefficient if number of pre-periods = 1. Default equals null.
+  Vector of M values for which the user wishes to construct robust confidence intervals. If NULL, the function constructs a grid of length 10 that starts at M = 0 and ends at M equal to the upper bound constructed from the pre-periods using the function DeltaSD_upperBound_Mpre if number of pre-periods > 1 or the standard deviation of the first pre-period coefficient if number of pre-periods = 1. Default equals null.
   }
 
 \item{Mbarvec}{

--- a/man/mboot.Rd
+++ b/man/mboot.Rd
@@ -4,7 +4,7 @@
 \alias{mboot}
 \title{Multiplier Bootstrap}
 \usage{
-mboot(inf.func, DIDparams)
+mboot(inf.func, DIDparams, pl = FALSE, cores = 1)
 }
 \arguments{
 \item{inf.func}{an influence function}

--- a/man/pre_process_did.Rd
+++ b/man/pre_process_did.Rd
@@ -154,11 +154,9 @@ extra estimate in an earlier period.}
 \item{print_details}{Whether or not to show details/progress of computations.
 Default is \code{FALSE}.}
 
-\item{pl}{Whether or not to use parallel processing
-(not implemented yet)}
+\item{pl}{Whether or not to use parallel processing}
 
-\item{cores}{The number of cores to use for parallel processing
-(not implemented yet)}
+\item{cores}{The number of cores to use for parallel processing}
 
 \item{call}{Function call to att_gt}
 }


### PR DESCRIPTION
Reprex on speedup (about 25% on this data size)

``` r
library(did)

time.periods <- 15
n <- 10000

# unit data
id <- 1:n
group <- sample(seq(10, 16), n, replace = TRUE)
unit_data <- data.frame(id = id, group = group)

# generate panel data
panel_data <- data.frame(
  id = sort(rep(id, time.periods)),
  tp = rep(rep(1:time.periods), n)
)
panel_data <- merge(panel_data, unit_data, by = "id")
panel_data$D <- 1 * (panel_data$tp >= panel_data$group)

# generate heterogeneous treatment effects by calendar date
tau <- (panel_data$D == 1) * (panel_data$tp - 12.5)
panel_data$Y <- panel_data$id + 3 * panel_data$tp +
  tau * panel_data$D + rnorm(nrow(panel_data))

head(panel_data)
#>   id tp group D         Y
#> 1  1  1    13 0  3.901901
#> 2  1  2    13 0  7.186365
#> 3  1  3    13 0 10.446138
#> 4  1  4    13 0 11.011049
#> 5  1  5    13 0 15.943329
#> 6  1  6    13 0 19.768032

bench::mark(
  did_1core = att_gt(
    yname = "Y", gname = "group", idname = "id", tname = "tp",
    data = panel_data, bstrap = TRUE, biters = 1000,
    pl = FALSE
  ),
  did_4core = att_gt(
    yname = "Y", gname = "group", idname = "id", tname = "tp",
    data = panel_data, bstrap = TRUE, biters = 1000,
    pl = TRUE, cores = 4
  ),
  did_8core = att_gt(
    yname = "Y", gname = "group", idname = "id", tname = "tp",
    data = panel_data, bstrap = TRUE, biters = 1000,
    pl = TRUE, cores = 8
  ),
  did_12core = att_gt(
    yname = "Y", gname = "group", idname = "id", tname = "tp",
    data = panel_data, bstrap = TRUE, biters = 1000,
    pl = TRUE, cores = 12
  ),
  iterations = 5,
  check = FALSE,
  memory = FALSE
)
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 4 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 did_1core     2.73s    2.78s     0.342        NA     24.2
#> 2 did_4core     2.15s    2.24s     0.449        NA     29.0
#> 3 did_8core     2.07s     2.1s     0.473        NA     30.8
#> 4 did_12core    2.12s    2.18s     0.462        NA     30.6
```

<sup>Created on 2022-06-06 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>