### PR TITLE
Fix harmless misspellings in vignettes

### DIFF
--- a/vignettes/TWFE.Rmd
+++ b/vignettes/TWFE.Rmd
@@ -135,7 +135,7 @@ plot1 <- data %>%
         axis.title = element_text(size = 14),
         axis.text = element_text(size = 12))  +
   ggtitle("One draw of the DGP with homogeneous effects across cohorts \n and with all groups being eventually treated")+
-  theme(plot.title = element_text(hjust = 0.5, size=12))
+  theme(plot.title = element_text(hjust = 0.5, size = 12))
 
 plot1
 
@@ -223,7 +223,7 @@ ES_plot_classical <- data_classical %>%
         axis.text = element_text(size = 12)) +
   ggtitle("TWFE event-study regression with binned end-points")+
   scale_color_manual(values = colors) + 
-  theme(plot.title = element_text(hjust = 0.5, size=12),
+  theme(plot.title = element_text(hjust = 0.5, size = 12),
         legend.position = "bottom", 
         legend.title = element_blank())
 
@@ -309,7 +309,7 @@ ES_plot_sat <- data_sat %>%
         axis.text = element_text(size = 12)) +
   ggtitle("TWFE event-study regression with 'all' leads and lags")+
   scale_color_manual(values = colors) + 
-  theme(plot.title = element_text(hjust = 0.5, size=12),
+  theme(plot.title = element_text(hjust = 0.5, size = 12),
         legend.position = "bottom", 
         legend.title = element_blank())
         
@@ -340,7 +340,7 @@ run_CS <- function(...) {
                      tname = "year",
                      idname = "unit",
                      gname = "cohort_year",
-                     control_group= "notyettreated",
+                     control_group = "notyettreated",
                      bstrap = FALSE,
                      data = data,
                      print_details = FALSE)
@@ -378,7 +378,7 @@ ES_plot_CS <- data_CS %>%
         axis.text = element_text(size = 12)) +
   ggtitle("Event-study-parameters estimated using Callaway and Sant'Anna (2021)\nComparison group: Not-yet-treated")+
     scale_color_manual(values = colors) + 
-  theme(plot.title = element_text(hjust = 0.5, size=12),
+  theme(plot.title = element_text(hjust = 0.5, size = 12),
         legend.position = "bottom", 
         legend.title = element_blank())
 
@@ -487,7 +487,7 @@ plot2 <- data %>%
   scale_color_manual(labels = c("1986", "1992", "1998", "Never-treated"),
                      values = c("#E41A1C", "#377EB8", "#4DAF4A", "#984EA3"))+
   ggtitle("One draw of the DGP with homogeneous effects across cohorts \n and with a never-treated group")+
-  theme(plot.title = element_text(hjust = 0.5, size=12))
+  theme(plot.title = element_text(hjust = 0.5, size = 12))
 
 plot2 
 
@@ -568,7 +568,7 @@ ES_plot_classical_never <- data_classical_never %>%
         axis.text = element_text(size = 12))+
   ggtitle("TWFE event-study regression with binned end-points")+
     scale_color_manual(values = colors) + 
-  theme(plot.title = element_text(hjust = 0.5, size=12),
+  theme(plot.title = element_text(hjust = 0.5, size = 12),
         legend.position = "bottom", 
         legend.title = element_blank())
 
@@ -650,7 +650,7 @@ ES_plot_sat_never <- data_sat_never %>%
         axis.text = element_text(size = 12))+
   ggtitle("TWFE event-study regression with 'all' leads and lags")+
   scale_color_manual(values = colors) + 
-  theme(plot.title = element_text(hjust = 0.5, size=12),
+  theme(plot.title = element_text(hjust = 0.5, size = 12),
         legend.position = "bottom", 
         legend.title = element_blank())
 
@@ -664,7 +664,7 @@ ES_plot_sat_never
 As the result above shows, when you have a never-treated group, treatment effects are homogeneous across cohorts, and you do not bin event-times, TWFE event-study regressions do recover the true underlying dynamic treatment effects. 
 
 
-### Using the Callaway and Sant'Anna (202) framework
+### Using the Callaway and Sant'Anna (2021) framework
 
 Next, we show that the procedure put forward by Callaway and Sant'Anna (2021) and implemented in our **did** can also be used in this setup.
 
@@ -686,7 +686,7 @@ run_CS_never <- function(...) {
                      tname = "year",
                      idname = "unit",
                      gname = "cohort_year",
-                     control_group= "never_treated",
+                     control_group = "never_treated",
                      bstrap = FALSE,
                      data = data,
                      print_details = FALSE)
@@ -724,7 +724,7 @@ ES_plot_CS_never <- data_CS_never %>%
         axis.text = element_text(size = 12))+
   ggtitle("Event-study-parameters estimated using Callaway and Sant'Anna (2021)\nComparison group: Never-treated units")+
   scale_color_manual(values = colors) + 
-  theme(plot.title = element_text(hjust = 0.5, size=12),
+  theme(plot.title = element_text(hjust = 0.5, size = 12),
         legend.position = "bottom", 
         legend.title = element_blank())
 
@@ -751,7 +751,7 @@ run_CS_ny <- function(...) {
                      tname = "year",
                      idname = "unit",
                      gname = "cohort_year",
-                     control_group= "notyettreated",
+                     control_group = "notyettreated",
                      bstrap = FALSE,
                      data = data,
                      print_details = FALSE)
@@ -789,7 +789,7 @@ ES_plot_CS_ny <- data_CS_ny %>%
         axis.text = element_text(size = 12))+
   ggtitle("Event-study-parameters estimated using Callaway and Sant'Anna (2021)\nComparison group: Not-yet-treated units")+
   scale_color_manual(values = colors) + 
-  theme(plot.title = element_text(hjust = 0.5, size=12),
+  theme(plot.title = element_text(hjust = 0.5, size = 12),
         legend.position = "bottom", 
         legend.title = element_blank())
 
@@ -895,7 +895,7 @@ plot3 <- data %>%
   scale_color_manual(labels = c("1986", "1992", "1998", "Never-treated"),
                      values = c("#E41A1C", "#377EB8", "#4DAF4A", "#984EA3")) +
   ggtitle("One draw of the DGP with heterogeneous treatment effect dynamics across cohorts \n and with a never-treated group")+
-  theme(plot.title = element_text(hjust = 0.5, size=12))
+  theme(plot.title = element_text(hjust = 0.5, size = 12))
 
 plot3 
 
@@ -976,7 +976,7 @@ ES_plot_classical_never_het <- data_classical_never_het %>%
         axis.text = element_text(size = 12))+
   ggtitle("TWFE event-study regression with binned end-points")+
   scale_color_manual(values = colors) + 
-  theme(plot.title = element_text(hjust = 0.5, size=12),
+  theme(plot.title = element_text(hjust = 0.5, size = 12),
         legend.position = "bottom", 
         legend.title = element_blank())
 
@@ -1058,7 +1058,7 @@ ES_plot_sat_never_het <- data_sat_never_het %>%
         axis.text = element_text(size = 12))+
   ggtitle("TWFE event-study regression with 'all' leads and lags")+
   scale_color_manual(values = colors) + 
-  theme(plot.title = element_text(hjust = 0.5, size=12),
+  theme(plot.title = element_text(hjust = 0.5, size = 12),
         legend.position = "bottom", 
         legend.title = element_blank())
 
@@ -1090,7 +1090,7 @@ run_CS_never_het <- function(...) {
                      tname = "year",
                      idname = "unit",
                      gname = "cohort_year",
-                     control_group= "never_treated",
+                     control_group = "never_treated",
                      bstrap = FALSE,
                      data = data,
                      print_details = FALSE)
@@ -1128,7 +1128,7 @@ ES_plot_CS_never_het <- data_CS_never_het %>%
         axis.text = element_text(size = 12))+
   ggtitle("Event-study-parameters estimated using Callaway and Sant'Anna (2021)\nComparison group: Never-treated units")+
   scale_color_manual(values = colors) + 
-  theme(plot.title = element_text(hjust = 0.5, size=12),
+  theme(plot.title = element_text(hjust = 0.5, size = 12),
         legend.position = "bottom", 
         legend.title = element_blank())
 
@@ -1156,7 +1156,7 @@ run_CS_ny_het <- function(...) {
                      tname = "year",
                      idname = "unit",
                      gname = "cohort_year",
-                     control_group= "notyettreated",
+                     control_group = "notyettreated",
                      bstrap = FALSE,
                      data = data,
                      print_details = FALSE)
@@ -1194,7 +1194,7 @@ ES_plot_CS_ny_het <- data_CS_ny_het %>%
         axis.text = element_text(size = 12))+
   ggtitle("Event-study-parameters estimated using Callaway and Sant'Anna (2021)\nComparison group: Not-yet-treated units")+
   scale_color_manual(values = colors) + 
-  theme(plot.title = element_text(hjust = 0.5, size=12),
+  theme(plot.title = element_text(hjust = 0.5, size = 12),
         legend.position = "bottom", 
         legend.title = element_blank())
 

--- a/vignettes/did-basics.Rmd
+++ b/vignettes/did-basics.Rmd
@@ -288,7 +288,7 @@ mw.attgt <- att_gt(yname = "lemp",
                    idname = "countyreal",
                    tname = "year",
                    xformla = ~1,
-                   data = mpdta,
+                   data = mpdta
                    )
 
 # summarize the results
@@ -296,7 +296,7 @@ summary(mw.attgt)
 
 # plot the results
 # set ylim so that all plots have the same scale along y-axis
-ggdid(mw.attgt, ylim = c(-.3,.3))
+ggdid(mw.attgt, ylim = c(-.3, .3))
 ```
 
 There are a few things to notice in this case
@@ -309,7 +309,7 @@ There are a few things to notice in this case
 # aggregate the group-time average treatment effects
 mw.dyn <- aggte(mw.attgt, type = "dynamic")
 summary(mw.dyn)
-ggdid(mw.dyn, ylim = c(-.3,.3))
+ggdid(mw.dyn, ylim = c(-.3, .3))
 ```
 
 These continue to be simultaneous confidence bands for dynamic effects. The results are broadly similar to the ones from the group-time average treatment effects:  one fails to reject parallel trends in pre-treatment periods and it looks like somewhat negative effects of the minimum wage on youth employment.
@@ -320,21 +320,21 @@ One way to combat this is to balance the sample by (i) only including groups tha
 are treated in 2004 and 2006 (so we can compute event-study-type parameters for them for $e=0,1$), drops the group treated in 2007 (as we can not compute the event-study-type parameter with $e=1$ for this group)), and then only looks at instantaneous average effects and the average effect one period after states raised the minimum wage.
 
 ```{r,  fig.width=8,fig.height=5, fig.align='center', out.width="90%", dpi = 200}
-mw.dyn.balance <- aggte(mw.attgt, type = "dynamic", balance_e=1)
+mw.dyn.balance <- aggte(mw.attgt, type = "dynamic", balance_e = 1)
 summary(mw.dyn.balance)
-ggdid(mw.dyn.balance, ylim = c(-.3,.3))
+ggdid(mw.dyn.balance, ylim = c(-.3, .3))
 ```
 
 Finally, we can run all the same results including a covariate.  In this application the results turn out to be nearly identical, and here we provide just the code for estimating the group-time average treatment effects while including covariates.  The other steps are otherwise the same.
 
 ```{r eval=FALSE}
 mw.attgt.X <- att_gt(yname = "lemp",
-                   gname = "first.treat",
-                   idname = "countyreal",
-                   tname = "year",
-                   xformla = ~lpop,
-                   data = mpdta,
-                   )
+                     gname = "first.treat",
+                     idname = "countyreal",
+                     tname = "year",
+                     xformla = ~lpop,
+                     data = mpdta
+                     )
 ```
 
 

--- a/vignettes/pre-testing.Rmd
+++ b/vignettes/pre-testing.Rmd
@@ -101,8 +101,8 @@ Dtl <- sapply(-(time.periods-1):(time.periods-2), function(l) {
     dtl
 })
 Dtl <- as.data.frame(Dtl)
-cnames1 <- paste0("Dtmin",(time.periods-1):1)
-colnames(Dtl) <- c(cnames1, paste0("Dt",0:(time.periods-2)))
+cnames1 <- paste0("Dtmin", (time.periods-1):1)
+colnames(Dtl) <- c(cnames1, paste0("Dt", 0:(time.periods-2)))
 data <- cbind.data.frame(data, Dtl)
 row.names(data) <- NULL
 
@@ -118,8 +118,8 @@ library(plm)
 # run event study regression
 # normalize effect to be 0 in pre-treatment period
 es <- plm(Y ~ Dtmin3 + Dtmin2 + Dt0 + Dt1 + Dt2, 
-          data=data, model="within", effect="twoways",
-          index=c("id","period"))
+          data = data, model = "within", effect = "twoways",
+          index = c("id", "period"))
 
 summary(es)
 
@@ -141,11 +141,11 @@ cmat <- data.frame(coefs=coefs, ses=ses, exposure=exposure)
 
 library(ggplot2)
 
-ggplot(data=cmat, mapping=aes(y=coefs, x=exposure)) +
-  geom_line(linetype="dashed") +
+ggplot(data = cmat, mapping = aes(y = coefs, x = exposure)) +
+  geom_line(linetype = "dashed") +
   geom_point() + 
-  geom_errorbar(aes(ymin=(coefs-1.96*ses), ymax=(coefs+1.96*ses)), width=0.2) +
-  ylim(c(-2,5)) +
+  geom_errorbar(aes(ymin = (coefs-1.96*ses), ymax = (coefs+1.96*ses)), width = 0.2) +
+  ylim(c(-2, 5)) +
   theme_bw()
 ```
 
@@ -154,13 +154,13 @@ You will notice that everything looks good here.  The pre-test performs well (th
 We can compare this to what happens using the `did` package:
 ```{r, fig.width=8,fig.height=10, fig.align='center', out.width="90%", dpi = 200}
 # estimate group-group time average treatment effects
-did_att_gt <- att_gt(yname="Y",
-                     tname="period",
-                     idname="id",
-                     gname="G",
-                     data=data,
-                     bstrap=FALSE,
-                     cband=FALSE)
+did_att_gt <- att_gt(yname = "Y",
+                     tname = "period",
+                     idname = "id",
+                     gname = "G",
+                     data = data,
+                     bstrap = FALSE,
+                     cband = FALSE)
 summary(did_att_gt)
 
 # plot them
@@ -170,7 +170,7 @@ ggdid(did_att_gt)
 
 ```{r, fig.width=8,fig.height=5, fig.align='center', out.width="90%", dpi = 200}
 # aggregate them into event study plot
-did_es <- aggte(did_att_gt, type="dynamic")
+did_es <- aggte(did_att_gt, type = "dynamic")
 
 # plot the event study
 ggdid(did_es)
@@ -228,8 +228,8 @@ Dtl <- sapply(-(time.periods-1):(time.periods-2), function(l) {
     dtl
 })
 Dtl <- as.data.frame(Dtl)
-cnames1 <- paste0("Dtmin",(time.periods-1):1)
-colnames(Dtl) <- c(cnames1, paste0("Dt",0:(time.periods-2)))
+cnames1 <- paste0("Dtmin", (time.periods-1):1)
+colnames(Dtl) <- c(cnames1, paste0("Dt", 0:(time.periods-2)))
 data <- cbind.data.frame(data, Dtl)
 row.names(data) <- NULL
 
@@ -245,8 +245,8 @@ library(plm)
 # run event study regression
 # normalize effect to be 0 in pre-treatment period
 es <- plm(Y ~ Dtmin3 + Dtmin2 + Dt0 + Dt1 + Dt2, 
-          data=data, model="within", effect="twoways", 
-          index=c("id","period"))
+          data = data, model = "within", effect = "twoways", 
+          index = c("id", "period"))
 
 summary(es)
 ```
@@ -267,7 +267,7 @@ coefs <- c(coefs1[idx.pre], 0, coefs1[idx.post])
 ses <- c(ses1[idx.pre], 0, ses1[idx.post])
 exposure <- -(time.periods-1):(time.periods-2)
 
-cmat <- data.frame(coefs=coefs, ses=ses, exposure=exposure)
+cmat <- data.frame(coefs = coefs, ses = ses, exposure = exposure)
 ```
 
 
@@ -275,11 +275,11 @@ cmat <- data.frame(coefs=coefs, ses=ses, exposure=exposure)
 # run through same code as before...omitted
 
 # new event study plot
-ggplot(data=cmat, mapping=aes(y=coefs, x=exposure)) +
-  geom_line(linetype="dashed") +
+ggplot(data = cmat, mapping = aes(y = coefs, x = exposure)) +
+  geom_line(linetype = "dashed") +
   geom_point() + 
-  geom_errorbar(aes(ymin=(coefs-1.96*ses), ymax=(coefs+1.96*ses)), width=0.2) +
-  ylim(c(-2,5)) +
+  geom_errorbar(aes(ymin = (coefs-1.96*ses), ymax = (coefs+1.96*ses)), width = 0.2) +
+  ylim(c(-2, 5)) +
   theme_bw()
 ```
 
@@ -288,11 +288,11 @@ In contrast to the last case, it is clear that things have gone wrong here.  **P
 We can compare this to what happens using the `did` package:
 ```{r, fig.width=8,fig.height=10, fig.align='center', out.width="90%", dpi = 200}
 # estimate group-group time average treatment effects
-did.att.gt <- att_gt(yname="Y",
-                     tname="period",
-                     idnam="id",
-                     gname="G",
-                     data=data
+did.att.gt <- att_gt(yname = "Y",
+                     tname = "period",
+                     idnam = "id",
+                     gname = "G",
+                     data = data
                      )
 summary(did.att.gt)
 
@@ -303,7 +303,7 @@ ggdid(did.att.gt)
 
 ```{r, fig.width=8,fig.height=5, fig.align='center', out.width="90%", dpi = 200}
 # aggregate them into event study plot
-did.es <- aggte(did.att.gt, type="dynamic")
+did.es <- aggte(did.att.gt, type = "dynamic")
 
 # plot the event study
 ggdid(did.es)
@@ -325,7 +325,7 @@ reset.sim()
 set.seed(1814)
 nt <- 1000
 nu <- 1000
-cdp <- conditional_did_pretest("Y", "period", "id", "G", xformla=~X, data=data)
+cdp <- conditional_did_pretest("Y", "period", "id", "G", xformla = ~X, data = data)
 cdp
 ```
 


### PR DESCRIPTION
- It fixes misspelling "Callaway and Sant'Anna (202)" to "Callaway and Sant'Anna (2021)" in **TWFE vignette**.
- It deletes two unnecessary commas in `att_gt()` in **did-basics vignette**.
- The rest of the changes are only spacings in the code to increase readability in vignettes, i.e. does not affect the functionality of the code.