### PR TITLE
implement fix suggested in issue 120

### DIFF
--- a/vignettes/did-basics.Rmd
+++ b/vignettes/did-basics.Rmd
@@ -88,6 +88,7 @@ set.seed(1814)
 
 # generate dataset with 4 time periods
 time.periods <- 4
+sp <- reset.sim(time.periods=time.periods)
 
 # add dynamic effects
 sp$te.e <- 1:time.periods


### PR DESCRIPTION
Some time ago, @bcallaway11 proposed a fix to #120. However, the fix didn't make it into the vignette - so when running just the first visible code snippet, users would get an error (as the `sp` object wasn't initialized).

I added @bcallaway11 proposed fix to the source code of the vignette. Maybe it helps others get started.

(Note that @bcallaway11 likely didn't see this bug because of running hidden (to the user) code (`echo=FALSE`) in the markdown document).

Hope this helps. Ignore if you feel otherwise.