### PR TITLE
Move sp list into main code chunk of tutorial for visibility

### DIFF
--- a/vignettes/did-basics.Rmd
+++ b/vignettes/did-basics.Rmd
@@ -76,17 +76,13 @@ library(did)
 #source(here::here("vignettes/setup_sims.R"))
 ```
 
-```{r, echo=FALSE}
-time.periods <- 4
-sp <- reset.sim()
-sp$te <- 0
-```
-
 ```{r, message = FALSE, warning = FALSE}
 # set seed so everything is reproducible
 set.seed(1814)
 
 # generate dataset with 4 time periods
+sp <- reset.sim()
+sp$te <- 0
 time.periods <- 4
 
 # add dynamic effects


### PR DESCRIPTION
When following the [did-basics tutorial](https://bcallaway11.github.io/did/articles/did-basics.html) I wanted to copy the first code chunk and run it locally.
However, the `sp` list object is defined implicit in the rmd-file, so the code snippet yields an error.
This PR moves the definition of the `sp` list into the main code chunk such that it can be copied, pasted & run without errors.