### PR TITLE
R universe

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -73,7 +73,7 @@ install.packages("did")
 Or, you can grab the latest development version from R-universe.
 
 ```{r r-universe-installation, eval = FALSE}
-install.packages('did', repos = "https://bcallaway11.r-universe.dev")
+install.packages("did", repos = "https://bcallaway11.r-universe.dev")
 ```
 
 ## A short example

--- a/README.Rmd
+++ b/README.Rmd
@@ -26,7 +26,7 @@ cat(
   badger::badge_cran_download("did", "grand-total", "blue"),
   badger::badge_cran_download("did", "last-month", "blue"),
   badger::badge_cran_release("did", "blue"),
-  badger::badge_devel("bcallaway11/did", "blue"),
+  badger::runiverse("did", "bcallaway11"),
   badger::badge_cran_checks("did"),
   # badger::badge_codecov("bcallaway11/did"),
   badger::badge_last_commit("bcallaway11/did")
@@ -64,17 +64,16 @@ There has been some recent work on DiD with multiple time periods.  The **did** 
 
 ## Installation
 
-You can install **did** from CRAN with:
+The stable version of **did** is available on CRAN.
 
 ```{r eval=FALSE}
 install.packages("did")
 ```
 
-or get the latest version from github with:
+Or, you can grab the latest development version from R-universe.
 
-```{r gh-installation, eval = FALSE}
-# install.packages("devtools")
-devtools::install_github("bcallaway11/did")
+```{r r-universe-installation, eval = FALSE}
+install.packages('did', repos = "https://bcallaway11.r-universe.dev")
 ```
 
 ## A short example

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ install.packages("did")
 Or, you can grab the latest development version from R-universe.
 
 ``` r
-install.packages('did', repos = "https://bcallaway11.r-universe.dev")
+install.packages("did", repos = "https://bcallaway11.r-universe.dev")
 ```
 
 ## A short example

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![](http://cranlogs.r-pkg.org/badges/grand-total/did?color=blue)](https://cran.r-project.org/package=did)
 [![](http://cranlogs.r-pkg.org/badges/last-month/did?color=blue)](https://cran.r-project.org/package=did)
 [![](https://www.r-pkg.org/badges/version/did?color=blue)](https://cran.r-project.org/package=did)
-[![](https://img.shields.io/badge/devel%20version-2.1.2-blue.svg)](https://github.com/bcallaway11/did)
+[![r-universe status badge](https://bcallaway11.r-universe.dev/badges/did)](https://bcallaway11.r-universe.dev/did)
 [![CRAN
 checks](https://badges.cranchecks.info/summary/did.svg)](https://cran.r-project.org/web/checks/check_results_did.html)
 [![](https://img.shields.io/github/last-commit/bcallaway11/did.svg)](https://github.com/bcallaway11/did/commits/master)
@@ -57,17 +57,16 @@ There has been some recent work on DiD with multiple time periods. The
 
 ## Installation
 
-You can install **did** from CRAN with:
+Or, you can grab the latest development version from R-universe.
 
 ``` r
 install.packages("did")
 ```
 
-or get the latest version from github with:
+Or, you can grab the latest development version from R-universe.
 
 ``` r
-# install.packages("devtools")
-devtools::install_github("bcallaway11/did")
+install.packages('did', repos = "https://bcallaway11.r-universe.dev")
 ```
 
 ## A short example


### PR DESCRIPTION
Hi folks,

This is just a small, suggestive PR that recommends R-universe for installing the development version of **did**, rather than going through devtools/remotes. You can see the end result on my fork: https://github.com/grantmcdermott/did/tree/r-universe

In general, I think that R-universe is the safer recommendation, since it ensures pre-compiled binaries for Mac and WIndows, and is also simpler since you only need to specify a different install target (as opposed to requiring a separate library).

Use, don't use!