### PR TITLE
minor improvements

### DIFF
--- a/R/compute.att_gt.R
+++ b/R/compute.att_gt.R
@@ -434,7 +434,7 @@ compute.att_gt <- function(dp) {
   update_inffunc <- rbindlist(lapply(seq_along(inffunc_updates), function(i) {
     update <- inffunc_updates[[i]]
     data.table(row = which(update$indices), col = i, value = update$values)
-  }))
+  }), fill = TRUE)
   # Apply updates to the sparse matrix
   inffunc[cbind(update_inffunc$row, update_inffunc$col)] <- update_inffunc$value
 

--- a/R/pre_process_did.R
+++ b/R/pre_process_did.R
@@ -103,9 +103,12 @@ pre_process_did <- function(yname,
 
 
   # Check if there is a never treated group
-  if ( length(glist[glist==0]) == 0) {
+  if (!any(glist == 0)) {
     if(control_group=="nevertreated"){
-      stop("There is no available never-treated group")
+      warning("No never-treated group is available. The last treated cohort is being coerced as never-treated units.")
+      max_g <- max(glist, na.rm = TRUE)
+      data[data[, gname] == max_g, gname] <- 0
+      glist <- sort(unique(data[, gname]))
     } else {
       # Drop all time periods with time periods >= latest treated
       data <- subset(data,(data[,tname] < (max(glist)-anticipation)))

--- a/R/pre_process_did2.R
+++ b/R/pre_process_did2.R
@@ -149,7 +149,12 @@ did_standarization <- function(data, args){
   # Check  if there is a never treated group in the data
   if (!(Inf %in% glist)) {
     if (args$control_group == "nevertreated") {
-      stop("There is no available never-treated group")
+      warning("No never-treated group is available. The last treated cohort is being coerced as never-treated units.")
+      max_g <- max(glist[is.finite(glist)], na.rm = TRUE)
+      # Convert the column to numeric so Inf can be stored
+      data[, (args$gname) := as.numeric(get(args$gname))]
+      data[get(args$gname) == max_g, (args$gname) := Inf]
+      glist <- sort(unique(data[[args$gname]]))
     } else {
       # Drop all time periods with time periods >= latest treated
       max_treated_time <- max(glist[is.finite(glist)], na.rm = TRUE)

--- a/tests/testthat/test-att_gt.R
+++ b/tests/testthat/test-att_gt.R
@@ -210,8 +210,8 @@ test_that("not yet treated comparison group", {
   expect_equal(res$att[1], 1, tol=.5)
 
 
-  # try to use never treated group as comparison group, should error
-  expect_error(att_gt(yname="Y", xformla=~X, data=data, tname="period",
+  # try to use never treated group as comparison group, should warning
+  expect_warning(att_gt(yname="Y", xformla=~X, data=data, tname="period",
                       control_group="nevertreated",
                       gname="G", est_method="dr", panel=FALSE))
 


### PR DESCRIPTION
This PR implements two minor improvements in `did`:
	1.	Handling Missing Never-Treated Groups:
When no never-treated group is available in data and the user impose "nevertreated" as control group, `did` now issues a warning instead of throwing an error. In this scenario, the last treated cohort (as defined by gname) is used as a "synthetic" never-treated group. We drop all the data from periods `>= max_g`. This is working with regular and faster mode.
	2.	Suppressing Warnings for Unbalanced Panels/RCS:
To resolve weird warnings that occur with unbalanced panels or repeated cross-sections, I've added a `fill=TRUE` argument when constructing the influence function matrix.
![image](https://github.com/user-attachments/assets/8c231030-233c-4338-b448-bf7ecd305e07)
 