### PR TITLE
Fix IF of weights for selective treatment timing

### DIFF
--- a/R/compute.aggte.R
+++ b/R/compute.aggte.R
@@ -289,7 +289,7 @@ compute.aggte <- function(MP,
                          pg=pgg,
                          weights.ind=weights.ind,
                          G=G,
-                         group=group)
+                         group=glist)
 
     # get overall influence function
     selective.inf.func <- get_agg_inf_func(att=selective.att.g,


### PR DESCRIPTION
Hi

Thanks for the paper and package!

I noticed that when computing `aggte` using `type = "group"` the resulting
influence function `selective.inf.func` is not mean zero (as it should).

**Script to reproduce**:

```R
devtools::load_all(".")
out <- att_gt(
  yname = "lemp",
  gname = "first.treat",
  idname = "countyreal",
  tname = "year",
  xformla = ~1,
  data = mpdta,
  est_method = "dr",
  bstrap = FALSE
)
es <- aggte(out, type = "group")
IF <- es$inf.function$selective.inf.func
print(es)
cat("\nMean of selective.wif:\n")
cat(mean(IF), "\n")

n <- length(IF)
se <- getSE(IF)
cat("Standard error of selective.wif:\n")
cat(se, "\n")
```

```bash
❯ Rscript test.R
ℹ Loading did
Warning message:
In compute.aggte(MP = MP, type = type, balance_e = balance_e, min_e = min_e,  :
  Used bootstrap procedure to compute simultaneous confidence band

Call:
aggte(MP = out, type = "group")

Reference: Callaway, Brantly and Pedro H.C. Sant'Anna.  "Difference-in-Differences with Multiple Time Periods." Journal of Econometrics, Vol. 225, No. 2, pp. 200-230, 2021. <https://doi.org/10.1016/j.jeconom.2020.12.001>, <https://arxiv.org/abs/1803.09015>


Overall summary of ATT's based on group/cohort aggregation:
    ATT    Std. Error     [ 95%  Conf. Int.]
 -0.031        0.0124    -0.0554     -0.0067 *


Group Effects:
 Group Estimate Std. Error [95% Pointwise  Conf. Band]
  2004  -0.0797     0.0264         -0.1375     -0.0220 *
  2006  -0.0229     0.0167         -0.0595      0.0137
  2007  -0.0261     0.0167         -0.0625      0.0104
---
Signif. codes: `*' confidence band does not cover 0

Control Group:  Never Treated,  Anticipation Periods:  0
Estimation Method:  Doubly Robust

Mean of selective.wif:
-0.003733846
Standard error of selective.wif:
0.01241527
```

The output above shows that `selective.wif` has mean equal to `-0.003733846`.

Setting a breakpoint
[here](https://github.com/bcallaway11/did/blob/master/R/compute.aggte.R#L293)
and sourcing the script I can see that neither of the columns of `selective.wif`
(influence functions) have zero mean, see output below.

```txt
[ins] Browse[1]> colMeans(selective.wif)
[1]  0.07181821  0.03892437 -0.11074258

[ins] Browse[1]> pgg
[1] 0.040 0.080 0.262

[ins] Browse[1]> group
 [1] 2 2 2 2 4 4 4 4 5 5 5 5

[ins] Browse[1]> glist
[1] 2 4 5
```

The reason is to be found
[here](https://github.com/bcallaway11/did/blob/master/R/compute.aggte.R#L288).
The `pgg` probabilities passed to `wif` do not match the groups in `group`.
The `group[k]` inside the `wif` function will pick out the wrong group when
computing `G==group[k]`; i.e. not the group corresponding to the probability
`pg[k]`.
Instead, the `glist` variable (see output above) should be passed to `wif`.

This pull requests fixes the bug by passing `glist` instead of `group` to the
function.

Rerunning the script yields:

```bash
❯ Rscript test.R
ℹ Loading did
Warning message:
In compute.aggte(MP = MP, type = type, balance_e = balance_e, min_e = min_e,  :
  Used bootstrap procedure to compute simultaneous confidence band

Call:
aggte(MP = out, type = "group")

Reference: Callaway, Brantly and Pedro H.C. Sant'Anna.  "Difference-in-Differences with Multiple Time Periods." Journal of Econometrics, Vol. 225, No. 2, pp. 200-230, 2021. <https://doi.org/10.1016/j.jeconom.2020.12.001>, <https://arxiv.org/abs/1803.09015>


Overall summary of ATT's based on group/cohort aggregation:
    ATT    Std. Error     [ 95%  Conf. Int.]
 -0.031        0.0124    -0.0554     -0.0066 *


Group Effects:
 Group Estimate Std. Error [95% Pointwise  Conf. Band]
  2004  -0.0797     0.0264         -0.1390     -0.0205 *
  2006  -0.0229     0.0167         -0.0604      0.0146
  2007  -0.0261     0.0167         -0.0635      0.0114
---
Signif. codes: `*' confidence band does not cover 0

Control Group:  Never Treated,  Anticipation Periods:  0
Estimation Method:  Doubly Robust

Mean of selective.wif:
-7.170049e-18
Standard error of selective.wif:
0.01244606
```

Now `selective.wif` is mean zero.
So all in all a change in the standard error from `0.01241527` to `0.01244606`;
not particularly huge in this case, but could be important in another setting
😄
