### PR TITLE
Dealing with no never treated units in data

### DIFF
--- a/R/compute.att_gt.R
+++ b/R/compute.att_gt.R
@@ -434,7 +434,7 @@ compute.att_gt <- function(dp) {
   update_inffunc <- rbindlist(lapply(seq_along(inffunc_updates), function(i) {
     update <- inffunc_updates[[i]]
     data.table(row = which(update$indices), col = i, value = update$values)
-  }))
+  }), fill = TRUE)
   # Apply updates to the sparse matrix
   inffunc[cbind(update_inffunc$row, update_inffunc$col)] <- update_inffunc$value
 

--- a/R/pre_process_did.R
+++ b/R/pre_process_did.R
@@ -103,22 +103,57 @@ pre_process_did <- function(yname,
 
 
   # Check if there is a never treated group
-  if ( length(glist[glist==0]) == 0) {
-    if(control_group=="nevertreated"){
-      stop("There is no available never-treated group")
+
+  # if ( length(glist[glist==0]) == 0) {
+  #   if(control_group=="nevertreated"){
+  #     stop("There is no available never-treated group")
+  #   } else {
+  #     # Drop all time periods with time periods >= latest treated
+  #     data <- subset(data,(data[,tname] < (max(glist)-anticipation)))
+  #     # Replace last treated time with zero
+  #     # lines.gmax <- data[,gname]==max(glist, na.rm = TRUE)
+  #     # data[lines.gmax,gname] <- 0
+  #
+  #     tlist <- sort(unique(data[,tname]))
+  #     glist <- sort(unique(data[,gname]))
+  #
+  #     # don't comput ATT(g,t) for groups that are only treated at end
+  #     # and only play a role as a comparison group
+  #     glist <- glist[ glist < max(glist)]
+  #   }
+  # }
+
+  if (!any(glist == 0)) {
+    # Compute latest treated cohort once, and the cutoff time
+    latest_g <- max(glist, na.rm = TRUE)
+    cutoff_t  <- latest_g - anticipation
+
+    if (control_group == "nevertreated") {
+      # Warn the user
+      warning(
+        "No never-treated group is available. ",
+        "The last treated cohort is being coerced as 'never-treated' units."
+      )
+
+      # Drop all periods ≥ (latest_g - anticipation)
+      data <- data[ data[[ tname ]] < cutoff_t, , drop = FALSE ]
+
+      # For any row where gname == latest_g, set gname := 0
+      lines.gmax <- data[, gname]==latest_g
+      data[lines.gmax, gname] <- 0
     } else {
-      # Drop all time periods with time periods >= latest treated
-      data <- subset(data,(data[,tname] < (max(glist)-anticipation)))
-      # Replace last treated time with zero
-      # lines.gmax <- data[,gname]==max(glist, na.rm = TRUE)
-      # data[lines.gmax,gname] <- 0
+      # If "notyetreated", we simply drop those periods and leave gnames alone
+      data <- data[ data[[ tname ]] < cutoff_t, , drop = FALSE ]
+    }
 
-      tlist <- sort(unique(data[,tname]))
-      glist <- sort(unique(data[,gname]))
+    # Recompute tlist and glist from the filtered/modified data
+    tlist <- sort(unique(data[,tname]))
+    glist <- sort(unique(data[,gname]))
 
-      # don't comput ATT(g,t) for groups that are only treated at end
-      # and only play a role as a comparison group
-      glist <- glist[ glist < max(glist)]
+
+    # If control_group != "nevertreated", drop the max cohort from glist
+    if (control_group != "nevertreated") {
+      glist <- glist[glist < latest_g]
     }
   }
 

--- a/tests/testthat/test-att_gt.R
+++ b/tests/testthat/test-att_gt.R
@@ -212,10 +212,18 @@ test_that("not yet treated comparison group", {
   expect_equal(res$att[1], 1, tol=.5)
 
 
-  # try to use never treated group as comparison group, should error
-  expect_error(att_gt(yname="Y", xformla=~X, data=data, tname="period",
+  # try to use never treated group as comparison group, should warn
+  expect_warning(nonev_orig <- att_gt(yname="Y", xformla=~X, data=data, tname="period",
                       control_group="nevertreated",
-                      gname="G", est_method="dr", panel=FALSE))
+                      gname="G", est_method="dr", panel=FALSE, faster_mode = FALSE))
+
+  # try to use never treated group as comparison group with faster mode, should warn
+  expect_warning(nonev_faster <- att_gt(yname="Y", xformla=~X, data=data, tname="period",
+                        control_group="nevertreated",
+                        gname="G", est_method="dr", panel=FALSE, faster_mode = TRUE))
+
+  # make use both methods give same ATT(g,t) with no never treated group
+  expect_equal(nonev_orig$att, nonev_faster$att)
 
 })
 


### PR DESCRIPTION
This PR supersedes [PR#220](https://github.com/bcallaway11/did/pull/220/files) and implements two minor improvements in `did`:

1. Handling Missing Never-Treated Groups:
When the data contain no never-treated units but the user specifies "nevertreated" as the control group, `did` now issues a warning instead of throwing an error. In this situation, the last treated cohort (as defined by gname) is used as a “synthetic” never-treated group. We then drop all observations from periods ≥ `latest_g`. This behavior applies in both the regular and fast estimation modes. Unit tests verify that a warning is raised and that both modes produce identical treatment‐effect estimates.

Unit test in test-att_gt.R, Lines 215-226
```
# try to use never treated group as comparison group, should warn
expect_warning(nonev_orig <- att_gt(yname="Y", xformla=~X, data=data, tname="period",
                    control_group="nevertreated",
                    gname="G", est_method="dr", panel=FALSE, faster_mode = FALSE))

# try to use never treated group as comparison group with faster mode, should warn
expect_warning(nonev_faster <- att_gt(yname="Y", xformla=~X, data=data, tname="period",
                      control_group="nevertreated",
                      gname="G", est_method="dr", panel=FALSE, faster_mode = TRUE))

# make sure both methods give same ATT(g,t) with no never treated group
expect_equal(nonev_orig$att, nonev_faster$att)
```

2. Suppressing Warnings for Unbalanced Panels/RCS:
To prevent spurious warnings in unbalanced panels or repeated cross‐section settings, I’ve added a `fill = TRUE` argument when constructing the influence‐function matrix. The warning previously read:

> Column 3 ['value'] of item 2 is missing in item 1. Use fill=TRUE to fill with NA (NULL for list columns), or use.names=FALSE to ignore column names. use.names='check' (default from v1.12.2) emits this message and proceeds as if use.names=FALSE for  backwards compatibility. See news item 5 in v1.12.2 for options to control this message.

All unit tests are passing from my end
![image](https://github.com/user-attachments/assets/ad9d424f-814e-4f87-a160-0922ff6706ad)
