### PR TITLE
Fix subscripts out bounds error with faster_mode=TRUE

### DIFF
--- a/R/compute.att_gt.R
+++ b/R/compute.att_gt.R
@@ -434,7 +434,7 @@ compute.att_gt <- function(dp) {
   update_inffunc <- rbindlist(lapply(seq_along(inffunc_updates), function(i) {
     update <- inffunc_updates[[i]]
     data.table(row = which(update$indices), col = i, value = update$values)
-  }))
+  }), fill = TRUE)
   # Apply updates to the sparse matrix
   inffunc[cbind(update_inffunc$row, update_inffunc$col)] <- update_inffunc$value
 

--- a/R/compute.att_gt2.R
+++ b/R/compute.att_gt2.R
@@ -276,7 +276,7 @@ run_att_gt_estimation <- function(g, t, dp2){
 
       # if there are not pre-treatment periods, code will
       # jump out of this loop
-      break
+      return(NULL)
     }
   }
 

--- a/R/pre_process_did.R
+++ b/R/pre_process_did.R
@@ -103,22 +103,57 @@ pre_process_did <- function(yname,
 
 
   # Check if there is a never treated group
-  if ( length(glist[glist==0]) == 0) {
-    if(control_group=="nevertreated"){
-      stop("There is no available never-treated group")
+
+  # if ( length(glist[glist==0]) == 0) {
+  #   if(control_group=="nevertreated"){
+  #     stop("There is no available never-treated group")
+  #   } else {
+  #     # Drop all time periods with time periods >= latest treated
+  #     data <- subset(data,(data[,tname] < (max(glist)-anticipation)))
+  #     # Replace last treated time with zero
+  #     # lines.gmax <- data[,gname]==max(glist, na.rm = TRUE)
+  #     # data[lines.gmax,gname] <- 0
+  #
+  #     tlist <- sort(unique(data[,tname]))
+  #     glist <- sort(unique(data[,gname]))
+  #
+  #     # don't comput ATT(g,t) for groups that are only treated at end
+  #     # and only play a role as a comparison group
+  #     glist <- glist[ glist < max(glist)]
+  #   }
+  # }
+
+  if (!any(glist == 0)) {
+    # Compute latest treated cohort once, and the cutoff time
+    latest_g <- max(glist, na.rm = TRUE)
+    cutoff_t  <- latest_g - anticipation
+
+    if (control_group == "nevertreated") {
+      # Warn the user
+      warning(
+        "No never-treated group is available. ",
+        "The last treated cohort is being coerced as 'never-treated' units."
+      )
+
+      # Drop all periods ≥ (latest_g - anticipation)
+      data <- data[ data[[ tname ]] < cutoff_t, , drop = FALSE ]
+
+      # For any row where gname == latest_g, set gname := 0
+      lines.gmax <- data[, gname]==latest_g
+      data[lines.gmax, gname] <- 0
     } else {
-      # Drop all time periods with time periods >= latest treated
-      data <- subset(data,(data[,tname] < (max(glist)-anticipation)))
-      # Replace last treated time with zero
-      # lines.gmax <- data[,gname]==max(glist, na.rm = TRUE)
-      # data[lines.gmax,gname] <- 0
+      # If "notyetreated", we simply drop those periods and leave gnames alone
+      data <- data[ data[[ tname ]] < cutoff_t, , drop = FALSE ]
+    }
 
-      tlist <- sort(unique(data[,tname]))
-      glist <- sort(unique(data[,gname]))
+    # Recompute tlist and glist from the filtered/modified data
+    tlist <- sort(unique(data[,tname]))
+    glist <- sort(unique(data[,gname]))
 
-      # don't comput ATT(g,t) for groups that are only treated at end
-      # and only play a role as a comparison group
-      glist <- glist[ glist < max(glist)]
+
+    # If control_group != "nevertreated", drop the max cohort from glist
+    if (control_group != "nevertreated") {
+      glist <- glist[glist < latest_g]
     }
   }
 

--- a/tests/testthat/test-att_gt.R
+++ b/tests/testthat/test-att_gt.R
@@ -212,10 +212,18 @@ test_that("not yet treated comparison group", {
   expect_equal(res$att[1], 1, tol=.5)
 
 
-  # try to use never treated group as comparison group, should error
-  expect_error(att_gt(yname="Y", xformla=~X, data=data, tname="period",
+  # try to use never treated group as comparison group, should warn
+  expect_warning(nonev_orig <- att_gt(yname="Y", xformla=~X, data=data, tname="period",
                       control_group="nevertreated",
-                      gname="G", est_method="dr", panel=FALSE))
+                      gname="G", est_method="dr", panel=FALSE, faster_mode = FALSE))
+
+  # try to use never treated group as comparison group with faster mode, should warn
+  expect_warning(nonev_faster <- att_gt(yname="Y", xformla=~X, data=data, tname="period",
+                        control_group="nevertreated",
+                        gname="G", est_method="dr", panel=FALSE, faster_mode = TRUE))
+
+  # make use both methods give same ATT(g,t) with no never treated group
+  expect_equal(nonev_orig$att, nonev_faster$att)
 
 })
 


### PR DESCRIPTION
**Issue:**
An error is triggered if the selected cohorts and time periods don’t form a continuous sequence:
`Error in dp2$outcomes_tensor[[t]] : subscript out of bounds`

**Description:**
The PR builds on previous [PR#229](https://github.com/bcallaway11/did/pull/229). Current PR updates the scripts when `faster_mode` is enabled so that, when the user filters down to non-contiguous periods (e.g. only years 2 and 4), the baseline period (`pret`) is correctly “snapped” to the nearest earlier available period, rather than being dropped entirely. As a result, all valid (g,t) cells will be estimated under `faster_mode = TRUE`, matching the original version under `faster_mode=FALSE`.

**Changes:**
* Drop the `reverse_mapping` step and restore the original `glist`/`tlist` logic used when `faster_mode = FALSE`.
* Simplified indexing logic inside `get_did_cohort_index()` function, which picks the units that will be involve in estimation at the current (g,t) cell. 
* Add unit test in `tests/testthat/test-att_gt.R` to catch this bad behaviour under `faster_mode=TRUE`.  This verifies that running att_gt() with and without faster_mode = TRUE yields identical ATT estimates.

All unit tests are passing from my end
![image](https://github.com/user-attachments/assets/bdddd244-9aa7-466c-8430-24ba522389a8)

**Speed unaffected:**
Micro-benchmarks confirm that after these fixes, it still delivers the same large speed-ups and lower memory consumption relative to the standard implementation. Here some evidence:

Panel data: unique ids = 10^order, where order in {2,...,6}, time periods = 10, DR estimation.
![image](https://github.com/user-attachments/assets/0002b1d6-1278-4d50-ac41-e8151cbcd5ad)
![image](https://github.com/user-attachments/assets/48275286-9ec4-4cee-ac9f-cb3865f7a4af)

Unbalanced panel/RCS: same setting as above but dropping obs from units randomly (~25%)
![image](https://github.com/user-attachments/assets/34b9cd2b-bf69-4b9c-8c70-2f668e71f7e9)
![image](https://github.com/user-attachments/assets/36e20f8e-c2a0-4b69-81f3-ff9484b876ed)
