### PR TITLE
fix t variable present in dataset

### DIFF
--- a/R/compute.att_gt.R
+++ b/R/compute.att_gt.R
@@ -95,8 +95,11 @@ compute.att_gt <- function(dp) {
       # that is, never treated + units that are eventually treated,
       # but not treated by the current period (+ anticipation)
       if(!nevertreated) {
+        # Capture loop variable t before data.table evaluation to avoid scoping issues
+        # (data.table expressions access columns by name, so 't' would refer to tname column)
+        time_threshold <- tlist[max(t, pret) + tfac] + anticipation
         data[, .C := as.integer((get(gname) == 0) |
-                                  ((get(gname) > (tlist[max(t, pret) + tfac] + anticipation)) &
+                                  ((get(gname) > time_threshold) &
                                      (get(gname) != glist[[..g]])))]
       }
 


### PR DESCRIPTION
This PR introduce a small fix in `R/compute.att_gt.R` when the dataset contain `t` as a name of a column. When using `control_group = "notyettreated"` with repeated cross-sections, the code was only including never-treated units in the control group, missing all "not-yet-treated" units, potentially generating errors when we aggregate influence functions vectors later. When `tname = "t"`, the data.table expression evaluated `max(t, pret)` using the column named "t" instead of the loop variable `t` causes  an incorrect time threshold for identifying not-yet-treated units.

The solution involves capturing the loop variable value before the `data.table` evaluation to avoid scoping issues in a new variable called `time_threshold`.

