### PR TITLE
Generalizing unit tests for faster_mode

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -18,3 +18,4 @@ Icon?
 ^CRAN-SUBMISSION$
 ^CITATION\.cff$
 ^R/honest_did$
+^CLAUDE\.md$

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ desktop.ini
 /Meta/
 did.Rproj
 ..Rcheck/
+CLAUDE.md
+.vscode/

--- a/R/compute.att_gt2.R
+++ b/R/compute.att_gt2.R
@@ -16,7 +16,7 @@ get_did_cohort_index <- function(group, time, tfac, pret, dp2){
   # based on control_group option
 
   min_control_group <-  ifelse((dp2$control_group == "notyettreated"),
-                               dp2$cohort_counts$cohort[which(dp2$cohort_counts$cohort > dp2$time_periods[max(time, pret) + tfac + dp2$anticipation])][1],
+                               dp2$cohort_counts$cohort[which(dp2$cohort_counts$cohort > dp2$time_periods[max(time, pret) + tfac ]+ dp2$anticipation)][1],
                                Inf)
   max_control_group <- Inf # always include the never treated units as the maximum. We add a correction in case is needed afterwards.
 
@@ -53,7 +53,7 @@ get_did_cohort_index <- function(group, time, tfac, pret, dp2){
       Cflag <- dat[[dp2$gname]] == Inf
     } else {  # not-yet-treated
       Cflag <- (dat[[dp2$gname]] == Inf) |
-        (dat[[dp2$gname]] > dp2$time_periods[max(time, pret) + tfac + dp2$anticipation] &
+        (dat[[dp2$gname]] > dp2$time_periods[max(time, pret) + tfac] + dp2$anticipation &
            dat[[dp2$gname]] != dp2$treated_groups[group])
     }
 

--- a/tests/testthat/test-inference.R
+++ b/tests/testthat/test-inference.R
@@ -20,9 +20,21 @@ library(BMisc)
 # library(ggplot2)
 # library(ggpubr)
 
+same_matrix_elem <- function(A, B) {
+  stopifnot(identical(dim(A), dim(B)))
+  colnames(A) <- NULL
+  colnames(B) <- NULL
+  dense_sort <- function(M) apply(as(M, "matrix"), 2, sort, na.last = TRUE)
+  all.equal(dense_sort(A), dense_sort(B))
+}
+
 temp_lib <- tempfile()
 dir.create(temp_lib)
-remotes::install_version("did", version = "2.1.2", lib = temp_lib, repos = "http://cran.us.r-project.org")
+# remotes::install_version("did", version = "2.1.2", lib = temp_lib, repos = "http://cran.us.r-project.org")
+install.packages(
+  "https://cran.r-project.org/src/contrib/did_2.1.2.tar.gz",
+  repos = NULL, type = "source", lib = temp_lib
+)
 
 test_that("inference with balanced panel data and aggregations", {
   sp <- did::reset.sim()
@@ -89,10 +101,13 @@ test_that("inference with balanced panel data and aggregations", {
   )
 
   # checks for ATT(g,t)'s
+  expect_true(all.equal(dr_2.1.2$att, dr_new$att))
+  expect_true(all.equal(reg_2.1.2$att, reg_new$att))
+  expect_true(all.equal(ipw_2.1.2$att, ipw_new$att))
   # check that the influence function is the same
-  expect_true(all(dr_new$inffunc == dr_2.1.2$inffunc))
-  expect_true(all(reg_new$inffunc == reg_2.1.2$inffunc))
-  expect_true(all(ipw_new$inffunc == ipw_2.1.2$inffunc))
+  expect_true(same_matrix_elem(dr_new$inffunc, dr_2.1.2$inffunc))
+  expect_true(same_matrix_elem(reg_new$inffunc, reg_2.1.2$inffunc))
+  expect_true(same_matrix_elem(ipw_new$inffunc, ipw_2.1.2$inffunc))
 
   # standard errors should be close
   # not totally sure, but I think slight differences are expected
@@ -214,10 +229,14 @@ test_that("inference with clustering", {
   )
 
   # checks for ATT(g,t)'s
+  expect_true(all.equal(dr_2.1.2$att, dr_new$att))
+  expect_true(all.equal(reg_2.1.2$att, reg_new$att))
+  expect_true(all.equal(ipw_2.1.2$att, ipw_new$att))
+
   # check that the influence function is the same
-  expect_true(all(dr_new$inffunc == dr_2.1.2$inffunc))
-  expect_true(all(reg_new$inffunc == reg_2.1.2$inffunc))
-  expect_true(all(ipw_new$inffunc == ipw_2.1.2$inffunc))
+  expect_true(same_matrix_elem(dr_new$inffunc, dr_2.1.2$inffunc))
+  expect_true(same_matrix_elem(reg_new$inffunc, reg_2.1.2$inffunc))
+  expect_true(same_matrix_elem(ipw_new$inffunc, ipw_2.1.2$inffunc))
 
   # standard errors should be close
   # not totally sure, but I think slight differences are expected
@@ -367,10 +386,13 @@ test_that("inference with repeated cross sections", {
   )
 
   # checks for ATT(g,t)'s
+  expect_true(all.equal(dr_2.1.2$att, dr_new$att))
+  expect_true(all.equal(reg_2.1.2$att, reg_new$att))
+  expect_true(all.equal(ipw_2.1.2$att, ipw_new$att))
   # check that the influence function is the same
-  expect_true(all(dr_new$inffunc == dr_2.1.2$inffunc))
-  expect_true(all(reg_new$inffunc == reg_2.1.2$inffunc))
-  expect_true(all(ipw_new$inffunc == ipw_2.1.2$inffunc))
+  expect_true(same_matrix_elem(dr_new$inffunc, dr_2.1.2$inffunc))
+  expect_true(same_matrix_elem(reg_new$inffunc, reg_2.1.2$inffunc))
+  expect_true(same_matrix_elem(ipw_new$inffunc, ipw_2.1.2$inffunc))
 
   # standard errors should be close
   # not totally sure, but I think slight differences are expected
@@ -492,10 +514,13 @@ test_that("inference with repeated cross sections and clustering", {
   )
 
   # checks for ATT(g,t)'s
+  expect_true(all.equal(dr_2.1.2$att, dr_new$att))
+  expect_true(all.equal(reg_2.1.2$att, reg_new$att))
+  expect_true(all.equal(ipw_2.1.2$att, ipw_new$att))
   # check that the influence function is the same
-  expect_true(all(dr_new$inffunc == dr_2.1.2$inffunc))
-  expect_true(all(reg_new$inffunc == reg_2.1.2$inffunc))
-  expect_true(all(ipw_new$inffunc == ipw_2.1.2$inffunc))
+  expect_true(same_matrix_elem(dr_new$inffunc, dr_2.1.2$inffunc))
+  expect_true(same_matrix_elem(reg_new$inffunc, reg_2.1.2$inffunc))
+  expect_true(same_matrix_elem(ipw_new$inffunc, ipw_2.1.2$inffunc))
 
   # standard errors should be close
   # not totally sure, but I think slight differences are expected
@@ -620,10 +645,13 @@ test_that("inference with unbalanced panel", {
   )
 
   # checks for ATT(g,t)'s
+  expect_true(all.equal(dr_2.1.2$att, dr_new$att))
+  expect_true(all.equal(reg_2.1.2$att, reg_new$att))
+  expect_true(all.equal(ipw_2.1.2$att, ipw_new$att))
   # check that the influence function is the same
-  expect_true(all(dr_new$inffunc == dr_2.1.2$inffunc))
-  expect_true(all(reg_new$inffunc == reg_2.1.2$inffunc))
-  expect_true(all(ipw_new$inffunc == ipw_2.1.2$inffunc))
+  expect_true(same_matrix_elem(dr_new$inffunc, dr_2.1.2$inffunc))
+  expect_true(same_matrix_elem(reg_new$inffunc, reg_2.1.2$inffunc))
+  expect_true(same_matrix_elem(ipw_new$inffunc, ipw_2.1.2$inffunc))
 
   # standard errors should be close
   # not totally sure, but I think slight differences are expected
@@ -746,10 +774,13 @@ test_that("inference with unbalanced panel and clustering", {
   )
 
   # checks for ATT(g,t)'s
+  expect_true(all.equal(dr_2.1.2$att, dr_new$att))
+  expect_true(all.equal(reg_2.1.2$att, reg_new$att))
+  expect_true(all.equal(ipw_2.1.2$att, ipw_new$att))
   # check that the influence function is the same
-  expect_true(all(dr_new$inffunc == dr_2.1.2$inffunc))
-  expect_true(all(reg_new$inffunc == reg_2.1.2$inffunc))
-  expect_true(all(ipw_new$inffunc == ipw_2.1.2$inffunc))
+  expect_true(same_matrix_elem(dr_new$inffunc,  dr_2.1.2$inffunc))
+  expect_true(same_matrix_elem(reg_new$inffunc, reg_2.1.2$inffunc))
+  expect_true(same_matrix_elem(ipw_new$inffunc,  ipw_2.1.2$inffunc))
 
   # standard errors should be close
   # not totally sure, but I think slight differences are expected


### PR DESCRIPTION
**Description:**
This PR updates unit tests that are valid to check potential errors under `faster_mode=TRUE`. The focus is on unit test for inference, since faster_mode uses an special order of the data making the comparison of influence functions across different versions challenging. I addded a function `same_matrix_elem` that allows to check if all the elements of the influence functions are equal after accounting for different orders. For sanity, unit tests will also check if the `att` and `se` outputs are indeed the same across versions.

Additionally this PR fix a small bug under `faster_mode=TRUE` when there is anticipation, no never-treated units in the data and the `notyettreated` option is being used as comparison group. 

**Instructions:**
1. Change the default argument in `att_gt.R` and set `faster_mode = TRUE` as default.
2. Import `library(testthat)`
3. run `devtools::load_all()` and `devtools::test()`

All units tests are passing regardless of what option is set for `faster_mode` argument
<img width="1208" height="171" alt="image" src="https://github.com/user-attachments/assets/aa835cf1-d323-4c4d-ae0d-ef1554be8d6d" />

Note: This PR does not affect any speed advantage from `faster_mode = TRUE`.