### PR TITLE
Improved cluster-robust inference

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # did 2.3.1.904
 
+  * The cluster-robust multiplier bootstrap (`mboot`) now follows Callaway & Sant'Anna (2021), Remark 10: it draws one multiplier per cluster and aggregates the influence function to cluster sums. For equal-sized clusters the standard errors are identical to before; for unbalanced clusters and repeated cross sections it uses the appropriate cluster-sum aggregation. All clustering input checks (numeric `clustervars`, at most one cluster dimension beyond `idname`, and cluster-variable time-invariance) are preserved
+
   * Fixed bug where `faster_mode = TRUE` and `faster_mode = FALSE` produced different ATT estimates when sampling weights (`weightsname`) vary across time. The fast path was always using first-period weights; it now correctly uses the same period's weights as the slow path
 
   * New `fix_weights` argument in `att_gt()` gives users explicit control over how time-varying sampling weights are resolved in each 2x2 DiD comparison. Options: `NULL` (default, preserves existing behavior), `"varying"` (per-observation weights using RC estimators), `"base_period"` (fix at g-1 for all cells), `"first_period"` (fix at first period). See `?att_gt` for details

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
   * Clustered standard errors are now available **without** the bootstrap. With `clustervars` set and `bstrap = FALSE`, `att_gt()` and `aggte()` report cluster-robust standard errors computed analytically from the cluster sums of the influence function (the same cluster-sum aggregation as the bootstrap), at every aggregation level (group-time, simple, group, dynamic, calendar). The pre-test Wald statistic is also reported under clustering in this case
 
+  * Clustered inference (bootstrap and analytical) is supported for panel data, unbalanced panels, and repeated cross sections, whether or not `idname` is supplied, and gives identical standard errors under `faster_mode = TRUE` and `faster_mode = FALSE`. For repeated cross sections without an `idname`, the internal observation id is used to align the cluster identifiers with the influence function
+
   * Fixed bug where `faster_mode = TRUE` and `faster_mode = FALSE` produced different ATT estimates when sampling weights (`weightsname`) vary across time. The fast path was always using first-period weights; it now correctly uses the same period's weights as the slow path
 
   * New `fix_weights` argument in `att_gt()` gives users explicit control over how time-varying sampling weights are resolved in each 2x2 DiD comparison. Options: `NULL` (default, preserves existing behavior), `"varying"` (per-observation weights using RC estimators), `"base_period"` (fix at g-1 for all cells), `"first_period"` (fix at first period). See `?att_gt` for details

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
   * The cluster-robust multiplier bootstrap (`mboot`) now follows Callaway & Sant'Anna (2021), Remark 10: it draws one multiplier per cluster and aggregates the influence function to cluster sums. For equal-sized clusters the standard errors are identical to before; for unbalanced clusters and repeated cross sections it uses the appropriate cluster-sum aggregation. All clustering input checks (numeric `clustervars`, at most one cluster dimension beyond `idname`, and cluster-variable time-invariance) are preserved
 
+  * Clustered standard errors are now available **without** the bootstrap. With `clustervars` set and `bstrap = FALSE`, `att_gt()` and `aggte()` report cluster-robust standard errors computed analytically from the cluster sums of the influence function (the same cluster-sum aggregation as the bootstrap), at every aggregation level (group-time, simple, group, dynamic, calendar). The pre-test Wald statistic is also reported under clustering in this case
+
   * Fixed bug where `faster_mode = TRUE` and `faster_mode = FALSE` produced different ATT estimates when sampling weights (`weightsname`) vary across time. The fast path was always using first-period weights; it now correctly uses the same period's weights as the slow path
 
   * New `fix_weights` argument in `att_gt()` gives users explicit control over how time-varying sampling weights are resolved in each 2x2 DiD comparison. Options: `NULL` (default, preserves existing behavior), `"varying"` (per-observation weights using RC estimators), `"base_period"` (fix at g-1 for all cells), `"first_period"` (fix at first period). See `?att_gt` for details

--- a/R/aggte.R
+++ b/R/aggte.R
@@ -33,9 +33,8 @@
 #'  all lengths of exposure are computed.
 #' @param na.rm Logical value if we are to remove missing Values from analyses. Defaults is FALSE.
 #' @param bstrap Boolean for whether or not to compute standard errors using
-#'  the multiplier bootstrap.  If standard errors are clustered, then one
-#'  must set `bstrap=TRUE`. Default is value set in the MP object.  If bstrap is `FALSE`, then analytical
-#'  standard errors are reported.
+#'  the multiplier bootstrap.  Default is value set in the MP object.  If `bstrap=FALSE`, then analytical
+#'  standard errors are reported; these are cluster-robust when a cluster variable was supplied to `att_gt`.
 #' @param biters The number of bootstrap iterations to use.  The default is the value set in the MP object,
 #'  and this is only applicable if `bstrap=TRUE`.
 #'

--- a/R/att_gt.R
+++ b/R/att_gt.R
@@ -423,9 +423,19 @@ att_gt <- function(yname,
   # aggregation of the multiplier bootstrap (Callaway & Sant'Anna 2021, Remark 10). It is kept on the same
   # 1/n scaling as the i.i.d. V so that se = sqrt(diag(V)/n) and the Wald statistic n * b' V^{-1} b stay
   # valid for either form.
-  cluster_vec <- dp$cluster_vector
   # cluster variables beyond idname; clustering on idname alone is just the unit-level (i.i.d.) SE
   extra_clustervars <- clustervars[!(clustervars %in% c(idname, ""))]
+  # Per-unit cluster identifiers aligned with the rows of inffunc. faster_mode supplies dp$cluster_vector;
+  # in slower mode derive it from the data exactly as mboot() does (one row per cross-sectional unit) and
+  # store it back, so the analytical clustered SE -- and aggte() downstream -- work for faster_mode TRUE/FALSE.
+  if (is.null(dp$cluster_vector) && length(extra_clustervars) > 0 && !is.null(dp$data)) {
+    cdat <- as.data.frame(dp$data)
+    if (all(c(idname, extra_clustervars) %in% names(cdat))) {
+      if (isTRUE(dp$panel)) cdat <- cdat[cdat[[tname]] == sort(unique(cdat[[tname]]))[1L], ]
+      dp$cluster_vector <- as.vector(unique(cdat[, c(idname, extra_clustervars)])[, extra_clustervars[1L]])
+    }
+  }
+  cluster_vec <- dp$cluster_vector
   cluster_analytic <- (length(extra_clustervars) > 0) && !bstrap &&
     !is.null(cluster_vec) && length(cluster_vec) == nrow(inffunc)
   if (cluster_analytic) {

--- a/R/att_gt.R
+++ b/R/att_gt.R
@@ -423,16 +423,19 @@ att_gt <- function(yname,
   # aggregation of the multiplier bootstrap (Callaway & Sant'Anna 2021, Remark 10). It is kept on the same
   # 1/n scaling as the i.i.d. V so that se = sqrt(diag(V)/n) and the Wald statistic n * b' V^{-1} b stay
   # valid for either form.
-  # cluster variables beyond idname; clustering on idname alone is just the unit-level (i.i.d.) SE
-  extra_clustervars <- clustervars[!(clustervars %in% c(idname, ""))]
+  # cluster variables beyond the unit id; clustering on the unit id alone is just the unit-level (i.i.d.)
+  # SE. Use the *internal* unit id dp$idname -- the user's idname for panels, and ".rowid" for repeated
+  # cross-sections / unbalanced panels (where the user may omit idname), mirroring how mboot() identifies units.
+  unit_id <- dp$idname
+  extra_clustervars <- clustervars[!(clustervars %in% c(unit_id, idname, ""))]
   # Per-unit cluster identifiers aligned with the rows of inffunc. faster_mode supplies dp$cluster_vector;
-  # in slower mode derive it from the data exactly as mboot() does (one row per cross-sectional unit) and
-  # store it back, so the analytical clustered SE -- and aggte() downstream -- work for faster_mode TRUE/FALSE.
-  if (is.null(dp$cluster_vector) && length(extra_clustervars) > 0 && !is.null(dp$data)) {
+  # in slower mode derive it from the data exactly as mboot() does -- one row per cross-sectional unit,
+  # keyed on the internal unit id -- and store it back, so the analytical clustered SE and aggte()
+  # downstream work for faster_mode TRUE and FALSE (including repeated cross-sections with idname omitted).
+  if (is.null(dp$cluster_vector) && length(extra_clustervars) > 0 && !is.null(dp$data) && !is.null(unit_id)) {
     cdat <- as.data.frame(dp$data)
-    if (all(c(idname, extra_clustervars) %in% names(cdat))) {
-      if (isTRUE(dp$panel)) cdat <- cdat[cdat[[tname]] == sort(unique(cdat[[tname]]))[1L], ]
-      dp$cluster_vector <- as.vector(unique(cdat[, c(idname, extra_clustervars)])[, extra_clustervars[1L]])
+    if (all(c(unit_id, extra_clustervars[1L]) %in% names(cdat))) {
+      dp$cluster_vector <- as.vector(unique(cdat[, c(unit_id, extra_clustervars[1L])])[, 2L])
     }
   }
   cluster_vec <- dp$cluster_vector

--- a/R/att_gt.R
+++ b/R/att_gt.R
@@ -66,17 +66,17 @@
 #'  }
 #' @param alp the significance level, default is 0.05
 #' @param bstrap Boolean for whether or not to compute standard errors using
-#'  the multiplier bootstrap.  If standard errors are clustered, then one
-#'  must set `bstrap=TRUE`. Default is `TRUE` (in addition, cband
+#'  the multiplier bootstrap.  Default is `TRUE` (in addition, cband
 #'  is also by default `TRUE` indicating that uniform confidence bands
-#'  will be returned.  If bstrap is `FALSE`, then analytical
-#'  standard errors are reported.
+#'  will be returned).  If `bstrap=FALSE`, analytical standard errors are
+#'  reported; these are cluster-robust when `clustervars` is supplied.
 #' @param biters The number of bootstrap iterations to use.  The default is 1000,
 #'  and this is only applicable if `bstrap=TRUE`.
 #' @param clustervars A vector of variables names to cluster on.  At most, there
 #'  can be two variables (otherwise will throw an error) and one of these
 #'  must be the same as idname which allows for clustering at the individual
-#'  level. By default, we cluster at individual level (when `bstrap=TRUE`).
+#'  level. Clustered standard errors are available with the multiplier bootstrap
+#'  (`bstrap=TRUE`) or analytically (`bstrap=FALSE`).
 #' @param cband Boolean for whether or not to compute a uniform confidence
 #'  band that covers all of the group-time average treatment effects
 #'  with fixed probability `1-alp`.  In order to compute uniform confidence
@@ -415,25 +415,34 @@ att_gt <- function(yname,
 
 
   # analytical standard errors
-  # estimate variance
-  # this is analogous to cluster robust standard errors that
-  # are clustered at the unit level
-
-  # note to self: this def. won't work with unbalanced panel,
-  # same with clustered standard errors
-  # but it is always ignored b/c bstrap has to be true in that case
+  # estimate variance. The i.i.d. form is clustered at the unit level; with a coarser cluster variable
+  # the variance is formed from cluster sums instead (the cluster_analytic branch below).
   n <- ifelse(faster_mode, dp$id_count, dp$n)
-  V <- Matrix::t(inffunc) %*% inffunc / (n)
+  # Analytical variance of the ATT(g,t)'s. With a cluster variable (beyond idname) and no bootstrap, use
+  # the cluster-robust form -- the cluster sums of the influence function -- mirroring the cluster-sum
+  # aggregation of the multiplier bootstrap (Callaway & Sant'Anna 2021, Remark 10). It is kept on the same
+  # 1/n scaling as the i.i.d. V so that se = sqrt(diag(V)/n) and the Wald statistic n * b' V^{-1} b stay
+  # valid for either form.
+  cluster_vec <- dp$cluster_vector
+  # cluster variables beyond idname; clustering on idname alone is just the unit-level (i.i.d.) SE
+  extra_clustervars <- clustervars[!(clustervars %in% c(idname, ""))]
+  cluster_analytic <- (length(extra_clustervars) > 0) && !bstrap &&
+    !is.null(cluster_vec) && length(cluster_vec) == nrow(inffunc)
+  if (cluster_analytic) {
+    Sc <- rowsum(as.matrix(inffunc), cluster_vec)   # n_clusters x k cluster sums
+    V  <- Matrix::Matrix(crossprod(Sc) / n)
+  } else {
+    V <- Matrix::t(inffunc) %*% inffunc / (n)
+  }
   se <- sqrt(Matrix::diag(V) / n)
 
   # Zero standard error replaced by NA
   se[se <= sqrt(.Machine$double.eps) * 10] <- NA
 
-  # if clustering along another dimension...we require using the
-  # bootstrap (in principle, could come up with an analytical standard
-  # errors here though)
-  if ((length(clustervars) > 0) & !bstrap) {
-    warning("Clustered standard errors require the bootstrap (bstrap = TRUE). Because bstrap = FALSE, the reported standard errors do NOT account for clustering.")
+  # If a cluster variable beyond idname is requested without the bootstrap but the cluster-robust variance
+  # could not be formed (e.g. cluster identifiers unavailable), fall back to i.i.d. and let the user know.
+  if ((length(extra_clustervars) > 0) & !bstrap & !cluster_analytic) {
+    warning("Clustered standard errors could not be computed analytically; the reported standard errors do NOT account for clustering. Set bstrap = TRUE for the cluster-robust multiplier bootstrap.")
   }
 
   # Identify entries of main diagonal V that are zero or NA
@@ -458,20 +467,16 @@ att_gt <- function(yname,
   # compute Wald pre-test
   #-----------------------------------------------------------------------------
 
-  # Determine whether the analytical V is a valid basis for the Wald pre-test.
-  # V = t(inffunc) %*% inffunc / n is valid for balanced panels, unbalanced
-  # panels (influence functions are aggregated to the unit level), and repeated
-  # cross-sections (CLT applies per independent observation).
-  #
-  # It is invalid when an extra cluster variable (beyond idname) is specified:
-  # the analytical V ignores between-cluster correlation, making the Wald stat
-  # anti-conservative.  In that case we skip the test and message the user to
-  # rely on bootstrap confidence intervals instead.
-
-  extra_clustervars <- clustervars[!(clustervars %in% c(idname, ""))]
+  # Determine whether the variance matrix V is a valid basis for the Wald pre-test. The i.i.d. form
+  # V = t(inffunc) %*% inffunc / n is valid for balanced panels, unbalanced panels (influence functions
+  # are aggregated to the unit level), and repeated cross-sections (CLT applies per independent
+  # observation). When a cluster variable beyond idname is specified and V is built from cluster sums
+  # (cluster_analytic, above), V is cluster-robust and the Wald test remains valid. It is only skipped
+  # when an extra cluster variable is present but V is the i.i.d. form (e.g. bstrap = TRUE), since then
+  # V ignores between-cluster correlation; in that case we rely on the bootstrap confidence bands.
 
   wald_invalid <- NULL
-  if (length(extra_clustervars) > 0) {
+  if (length(extra_clustervars) > 0 && !cluster_analytic) {
     wald_invalid <- paste0(
       "The Wald pre-test is not reported when clustering beyond the unit level ",
       "(clustervars = '", paste(extra_clustervars, collapse = "', '"), "') ",

--- a/R/compute.aggte.R
+++ b/R/compute.aggte.R
@@ -692,6 +692,15 @@ getSE <- function(thisinffunc, DIDparams = NULL) {
     bout <- mboot(thisinffunc, DIDparams)
     return(bout$se)
   } else {
+    # Analytical cluster-robust SE (no bootstrap): cluster sums of the aggregated influence function,
+    # matching the cluster-sum aggregation of the multiplier bootstrap (CS 2021, Remark 10). Falls back to
+    # the i.i.d. form when no cluster variable is supplied or cluster identifiers are unavailable.
+    cv <- if (!is.null(DIDparams)) DIDparams$cluster_vector else NULL
+    if (!is.null(DIDparams) && length(DIDparams$clustervars) > 0 &&
+        !is.null(cv) && length(cv) == length(thisinffunc)) {
+      S <- rowsum(thisinffunc, cv)
+      return(sqrt(sum(S^2)) / n)
+    }
     return(sqrt(mean((thisinffunc)^2) / n))
   }
 }

--- a/R/compute.aggte.R
+++ b/R/compute.aggte.R
@@ -681,11 +681,11 @@ get_agg_inf_func <- function(att, inffunc1, whichones, weights.agg, wif = NULL) 
 getSE <- function(thisinffunc, DIDparams = NULL) {
   alp <- .05
   bstrap <- FALSE
+  n <- length(thisinffunc)
   if (!is.null(DIDparams)) {
     bstrap <- DIDparams$bstrap
     alp <- DIDparams$alp
     cband <- DIDparams$cband
-    n <- length(thisinffunc)
   }
 
   if (bstrap) {
@@ -694,10 +694,11 @@ getSE <- function(thisinffunc, DIDparams = NULL) {
   } else {
     # Analytical cluster-robust SE (no bootstrap): cluster sums of the aggregated influence function,
     # matching the cluster-sum aggregation of the multiplier bootstrap (CS 2021, Remark 10). Falls back to
-    # the i.i.d. form when no cluster variable is supplied or cluster identifiers are unavailable.
+    # the i.i.d. form when there is no cluster variable beyond idname or cluster identifiers are unavailable.
+    # dp$cluster_vector is set by att_gt() for both faster_mode = TRUE and FALSE.
     cv <- if (!is.null(DIDparams)) DIDparams$cluster_vector else NULL
-    if (!is.null(DIDparams) && length(DIDparams$clustervars) > 0 &&
-        !is.null(cv) && length(cv) == length(thisinffunc)) {
+    extra_cl <- if (!is.null(DIDparams)) DIDparams$clustervars[!(DIDparams$clustervars %in% c(DIDparams$idname, ""))] else character(0)
+    if (length(extra_cl) > 0 && !is.null(cv) && length(cv) == length(thisinffunc)) {
       S <- rowsum(thisinffunc, cv)
       return(sqrt(sum(S^2)) / n)
     }

--- a/R/mboot.R
+++ b/R/mboot.R
@@ -85,11 +85,15 @@ mboot <- function(inf.func, DIDparams, pl = FALSE, cores = 1) {
   if (length(clustervars)==0) {
     bres <- sqrt(n) * run_multiplier_bootstrap(inf.func, biters, pl, cores)
   } else {
+    # Cluster-robust multiplier bootstrap following Callaway & Sant'Anna (2021, Remark 10): draw
+    # cluster-specific multipliers and apply them to the influence function aggregated to cluster
+    # *sums*, consistent with the (1/n) empirical average that defines the estimator. For
+    # equal-sized clusters this coincides with the previous aggregation; for unbalanced clusters and
+    # repeated cross-sections it keeps the bootstrap aligned with the cluster-robust variance.
     n_clusters <- length(unique(dta[,clustervars]))
     cluster <- unique(dta[,c(idname,clustervars)])[,2]
-    cluster_n <- aggregate(cluster, by=list(cluster), length)[,2]
-    cluster_mean_if <- rowsum(inf.func, cluster,reorder=TRUE) / cluster_n
-    bres <- sqrt(n_clusters) * run_multiplier_bootstrap(cluster_mean_if, biters, pl, cores)
+    cluster_sum_if <- rowsum(inf.func, cluster, reorder=TRUE)
+    bres <- sqrt(n_clusters) * run_multiplier_bootstrap(cluster_sum_if, biters, pl, cores)
   }
 
 
@@ -119,7 +123,11 @@ mboot <- function(inf.func, DIDparams, pl = FALSE, cores = 1) {
 
   #se <- rep(0, length(ndg.dim))
   se <- rep(NA, length(ndg.dim))
-  se[ndg.dim] <- as.numeric(bSigma) / sqrt(n_clusters)
+  # Standard error from the bootstrap interquartile-range scale. With cluster sums (above) this is the
+  # cluster-robust SE (1/n) * sqrt(sum_c S_c^2); without clustering n_clusters = n and it reduces to the
+  # i.i.d. form bSigma / sqrt(n). (Equivalent to the previous bSigma / sqrt(n_clusters) when clusters are
+  # equal-sized; the change matters only for unbalanced clusters / repeated cross-sections.)
+  se[ndg.dim] <- as.numeric(bSigma) * sqrt(n_clusters) / n
   #se[se==0] <- NA
 
   list(bres = bres, V = V, se = se, crit.val = crit.val)

--- a/R/pre_process_did2.R
+++ b/R/pre_process_did2.R
@@ -75,8 +75,10 @@ validate_args <- function(args, data){
       stop("You can only provide 1 cluster variable additionally to the one provided in idname. Please check your arguments.")
     }
 
-    # Check that cluster variables do not vary over time within each unit
-    if (length(args$clustervars) > 0) {
+    # Check that cluster variables do not vary over time within each unit. For true repeated cross-sections
+    # the user may omit idname (an internal ".rowid" is created later, one observation per row), so there is
+    # no within-unit time variation to check and idname is not yet available here -- skip the check then.
+    if (length(args$clustervars) > 0 && !is.null(args$idname)) {
       # Efficiently check for time-varying cluster variables
       clust_tv <- data[, lapply(.SD, function(col) length(unique(col)) == 1), by = get(args$idname), .SDcols = args$clustervars]
       # If any cluster variable varies over time within any unit, stop execution

--- a/man/aggte.Rd
+++ b/man/aggte.Rd
@@ -53,9 +53,8 @@ all lengths of exposure are computed.}
 \item{na.rm}{Logical value if we are to remove missing Values from analyses. Defaults is FALSE.}
 
 \item{bstrap}{Boolean for whether or not to compute standard errors using
-the multiplier bootstrap.  If standard errors are clustered, then one
-must set \code{bstrap=TRUE}. Default is value set in the MP object.  If bstrap is \code{FALSE}, then analytical
-standard errors are reported.}
+the multiplier bootstrap.  Default is value set in the MP object.  If \code{bstrap=FALSE}, then analytical
+standard errors are reported; these are cluster-robust when a cluster variable was supplied to \code{att_gt}.}
 
 \item{biters}{The number of bootstrap iterations to use.  The default is the value set in the MP object,
 and this is only applicable if \code{bstrap=TRUE}.}

--- a/man/att_gt.Rd
+++ b/man/att_gt.Rd
@@ -150,11 +150,10 @@ for repeated cross sections (\code{panel = FALSE}).}
 \item{alp}{the significance level, default is 0.05}
 
 \item{bstrap}{Boolean for whether or not to compute standard errors using
-the multiplier bootstrap.  If standard errors are clustered, then one
-must set \code{bstrap=TRUE}. Default is \code{TRUE} (in addition, cband
+the multiplier bootstrap.  Default is \code{TRUE} (in addition, cband
 is also by default \code{TRUE} indicating that uniform confidence bands
-will be returned.  If bstrap is \code{FALSE}, then analytical
-standard errors are reported.}
+will be returned).  If \code{bstrap=FALSE}, analytical standard errors are
+reported; these are cluster-robust when \code{clustervars} is supplied.}
 
 \item{cband}{Boolean for whether or not to compute a uniform confidence
 band that covers all of the group-time average treatment effects
@@ -168,7 +167,8 @@ and this is only applicable if \code{bstrap=TRUE}.}
 \item{clustervars}{A vector of variables names to cluster on.  At most, there
 can be two variables (otherwise will throw an error) and one of these
 must be the same as idname which allows for clustering at the individual
-level. By default, we cluster at individual level (when \code{bstrap=TRUE}).}
+level. Clustered standard errors are available with the multiplier bootstrap
+(\code{bstrap=TRUE}) or analytically (\code{bstrap=FALSE}).}
 
 \item{est_method}{the method to compute group-time average treatment effects.  The default is "dr" which uses the doubly robust
 approach in the \code{DRDID} package.  Other built-in methods

--- a/tests/testthat/test-cluster-analytic.R
+++ b/tests/testthat/test-cluster-analytic.R
@@ -58,8 +58,9 @@ test_that("analytical cluster SE agrees with the bootstrap cluster SE (multiple 
     d <- mk(11L, within)
     ra <- att_gt(yname="y", tname="t", idname="id", gname="g", data=d, control_group="nevertreated",
                  bstrap=FALSE, clustervars="cl", base_period="varying")
+    set.seed(11L)
     rb <- att_gt(yname="y", tname="t", idname="id", gname="g", data=d, control_group="nevertreated",
-                 bstrap=TRUE, biters=3000L, clustervars="cl", pl=FALSE, cband=FALSE, base_period="varying", seed=11L)
+                 bstrap=TRUE, biters=3000L, clustervars="cl", pl=FALSE, cband=FALSE, base_period="varying")
     k <- which(ra$group == 2L & ra$t == 2L)
     # the reported bootstrap SE (IQR scale) is within a few percent of the analytical at this G
     expect_lt(abs(rb$se[k] - ra$se[k]) / ra$se[k], 0.15)
@@ -68,6 +69,62 @@ test_that("analytical cluster SE agrees with the bootstrap cluster SE (multiple 
     set.seed(11L); bo <- mboot(as.matrix(ra$inffunc)[, k, drop = FALSE], dp)
     sd_se <- sd(as.numeric(bo$bres)) * sqrt(length(unique(dp$cluster_vector))) / nrow(ra$inffunc)
     expect_lt(abs(sd_se - ra$se[k]) / ra$se[k], 0.06)
+  }
+})
+
+# true repeated cross-sections: a fresh cross-section is drawn each period within each cluster, the cluster
+# shares a common per-period shock, and treatment is assigned at the cluster level. The cluster -- not the
+# (non-existent) panel unit -- is the independent sampling unit.
+.make_rcs <- function(seed, G = 60L, per_cell = 6L) {
+  set.seed(seed); per <- 1:4
+  gC <- sample(c(2L, 3L, 0L), G, replace = TRUE, prob = c(.34, .33, .33)); aC <- rnorm(G, 0, 1)
+  eta <- matrix(rnorm(G * 4L, 0, 1.5), G, 4L); rows <- list(); k <- 0L
+  for (cl in seq_len(G)) for (tt in per) {
+    y <- aC[cl] + 0.3 * tt + eta[cl, tt] + (gC[cl] != 0L & tt >= gC[cl]) + rnorm(per_cell)
+    k <- k + 1L; rows[[k]] <- data.frame(t = tt, cl = cl, g = gC[cl], y = y)
+  }
+  do.call(rbind, rows)[sample(G * 4L * per_cell), ]   # shuffle so row order is non-trivial
+}
+
+test_that("analytical clustered SE for repeated cross-sections (idname omitted/provided, faster_mode TRUE/FALSE)", {
+  d    <- .make_rcs(909L)
+  d_id <- d; d_id$uid <- seq_len(nrow(d_id))
+  se_om <- list()
+  for (fm in c(TRUE, FALSE)) {
+    # idname OMITTED: pre_process_did() creates an internal .rowid; clustering must still aggregate to
+    # cluster sums via that internal id (the function argument idname is NULL here).
+    r_om <- att_gt(yname = "y", tname = "t", gname = "g", data = d, control_group = "nevertreated",
+                   bstrap = FALSE, clustervars = "cl", panel = FALSE, base_period = "varying", faster_mode = fm)
+    # idname PROVIDED (a per-row observation id)
+    r_id <- att_gt(yname = "y", tname = "t", idname = "uid", gname = "g", data = d_id,
+                   control_group = "nevertreated", bstrap = FALSE, clustervars = "cl",
+                   panel = FALSE, base_period = "varying", faster_mode = fm)
+    for (r in list(r_om, r_id)) {
+      cv <- r$DIDparams$cluster_vector
+      expect_true(!is.null(cv) && length(cv) == nrow(r$inffunc))   # must be present and aligned
+      n <- nrow(r$inffunc); S <- rowsum(as.matrix(r$inffunc), cv)
+      se_target <- sqrt(colSums(S^2)) / n                          # cluster-sum CRVE per ATT(g,t)
+      ok <- is.finite(r$se) & is.finite(se_target)
+      expect_equal(unname(r$se[ok]), unname(se_target[ok]), tolerance = 1e-8)
+    }
+    se_om[[as.character(fm)]] <- r_om$se[which(r_om$group == 2L & r_om$t == 2L)]
+  }
+  # the two code paths derive the cluster vector independently, yet must give the same analytical SE
+  expect_equal(unname(se_om[["TRUE"]]), unname(se_om[["FALSE"]]), tolerance = 1e-6)
+})
+
+test_that("clustered bootstrap and analytical SE agree for repeated cross-sections (idname omitted)", {
+  skip_on_cran()  # bootstrap-heavy
+  d <- .make_rcs(910L)
+  for (fm in c(TRUE, FALSE)) {
+    ra <- att_gt(yname = "y", tname = "t", gname = "g", data = d, control_group = "nevertreated",
+                 bstrap = FALSE, clustervars = "cl", panel = FALSE, base_period = "varying", faster_mode = fm)
+    rb <- att_gt(yname = "y", tname = "t", gname = "g", data = d, control_group = "nevertreated",
+                 bstrap = TRUE, biters = 5000L, clustervars = "cl", pl = FALSE, cband = FALSE,
+                 panel = FALSE, base_period = "varying", faster_mode = fm)
+    k <- which(ra$group == 2L & ra$t == 2L)
+    expect_true(is.finite(rb$se[k]))
+    expect_lt(abs(rb$se[k] - ra$se[k]) / ra$se[k], 0.12)
   }
 })
 

--- a/tests/testthat/test-cluster-analytic.R
+++ b/tests/testthat/test-cluster-analytic.R
@@ -77,7 +77,7 @@ test_that("analytical clustered SE flows through aggte at all levels (simple/gro
                     control_group = "nevertreated", bstrap = FALSE, clustervars = "cl", base_period = "varying")
   res_iid <- att_gt(yname = "y", tname = "t", idname = "id", gname = "g", data = d,
                     control_group = "nevertreated", bstrap = FALSE, base_period = "varying")
-  skip_if_not(!is.null(res_cl$DIDparams$cluster_vector), "cluster_vector not available")
+  expect_true(!is.null(res_cl$DIDparams$cluster_vector))  # required for clustered SEs to propagate through aggte()
   for (ty in c("simple", "group", "dynamic")) {
     a_cl  <- suppressWarnings(aggte(res_cl,  type = ty, bstrap = FALSE))
     a_iid <- suppressWarnings(aggte(res_iid, type = ty, bstrap = FALSE))

--- a/tests/testthat/test-cluster-analytic.R
+++ b/tests/testthat/test-cluster-analytic.R
@@ -3,12 +3,13 @@
 # same cluster-sum aggregation as the multiplier bootstrap (Callaway & Sant'Anna 2021, Remark 10).
 library(testthat)
 
-# panel with cluster-by-time shocks -> genuine within-cluster correlation in the (first-differenced) IF
+# panel in which units within a cluster are dependent: they share a common shock each period (e.g. a
+# state-by-year shock), so the cluster -- not the individual unit -- is the independent sampling unit
 .make_clustered_shocks <- function(seed, G = 50L) {
   set.seed(seed)
   sz <- rep(c(1L, 2L, 4L, 10L), length.out = G); N <- sum(sz); cl <- rep(seq_len(G), times = sz)
   alpha <- rnorm(G, 0, 1)[cl]; nu <- rnorm(N, 0, 1); per <- 1:4
-  eta <- matrix(rnorm(G * 4L, 0, 1.5), G, 4L)                     # cluster-by-time shocks
+  eta <- matrix(rnorm(G * 4L, 0, 1.5), G, 4L)                     # common shock per cluster, per period
   g <- sample(c(2L, 3L, 0L), G, replace = TRUE, prob = c(.34, .33, .33))[cl]  # cluster-level treatment
   d <- data.frame(id = rep(seq_len(N), each = 4L), t = rep(per, N), cl = rep(cl, each = 4L),
                   g = rep(g, each = 4L), a = rep(alpha, each = 4L), nu = rep(nu, each = 4L))
@@ -16,29 +17,33 @@ library(testthat)
   d[order(d$id, d$t), ]
 }
 
-test_that("analytical (no-bootstrap) clustered SE for att_gt equals the cluster-sum CRVE", {
+test_that("analytical (no-bootstrap) clustered SE for att_gt equals the cluster-sum CRVE (faster_mode TRUE and FALSE)", {
   d <- .make_clustered_shocks(404L)
-  res <- att_gt(yname = "y", tname = "t", idname = "id", gname = "g", data = d,
-                control_group = "nevertreated", bstrap = FALSE, clustervars = "cl", base_period = "varying")
-  cv <- res$DIDparams$cluster_vector
-  skip_if_not(!is.null(cv) && length(cv) == nrow(res$inffunc), "cluster_vector not available/aligned")
-  n <- nrow(res$inffunc)
-  S <- rowsum(as.matrix(res$inffunc), cv)            # n_clusters x k cluster sums
-  se_target <- sqrt(colSums(S^2)) / n                 # cluster-sum CRVE per ATT(g,t)
-  ok <- is.finite(res$se) & is.finite(se_target)
-  # analytical => deterministic => exact match (no Monte Carlo tolerance needed)
-  expect_equal(unname(res$se[ok]), unname(se_target[ok]), tolerance = 1e-8)
+  for (fm in c(TRUE, FALSE)) {
+    res <- att_gt(yname = "y", tname = "t", idname = "id", gname = "g", data = d,
+                  control_group = "nevertreated", bstrap = FALSE, clustervars = "cl",
+                  base_period = "varying", faster_mode = fm)
+    cv <- res$DIDparams$cluster_vector
+    # the per-unit cluster vector must be available in BOTH modes (derived from data in slower mode)
+    expect_true(!is.null(cv) && length(cv) == nrow(res$inffunc))
+    n <- nrow(res$inffunc)
+    S <- rowsum(as.matrix(res$inffunc), cv)            # n_clusters x k cluster sums
+    se_target <- sqrt(colSums(S^2)) / n                 # cluster-sum CRVE per ATT(g,t)
+    ok <- is.finite(res$se) & is.finite(se_target)
+    # analytical => deterministic => exact match (no Monte Carlo tolerance needed)
+    expect_equal(unname(res$se[ok]), unname(se_target[ok]), tolerance = 1e-8)
 
-  # and it differs from the i.i.d. SE under within-cluster correlation
-  res_iid <- att_gt(yname = "y", tname = "t", idname = "id", gname = "g", data = d,
-                    control_group = "nevertreated", bstrap = FALSE, base_period = "varying")
-  k <- which(res$group == 2L & res$t == 2L)
-  expect_gt(abs(res$se[k] - res_iid$se[k]) / res_iid$se[k], 0.05)
+    # and it differs from the i.i.d. SE when the units within a cluster are dependent
+    res_iid <- att_gt(yname = "y", tname = "t", idname = "id", gname = "g", data = d,
+                      control_group = "nevertreated", bstrap = FALSE, base_period = "varying", faster_mode = fm)
+    k <- which(res$group == 2L & res$t == 2L)
+    expect_gt(abs(res$se[k] - res_iid$se[k]) / res_iid$se[k], 0.05)
+  }
 })
 
 test_that("analytical cluster SE agrees with the bootstrap cluster SE (multiple DGPs)", {
   skip_on_cran()  # bootstrap-heavy
-  # cluster-by-time shocks; treatment at the cluster level (within = FALSE) or within clusters (TRUE).
+  # units within a cluster share a common shock; treatment at the cluster level (within = FALSE) or within clusters (TRUE).
   mk <- function(seed, within, G = 60L) {
     set.seed(seed); sz <- rep(c(1L, 2L, 4L, 10L), length.out = G); N <- sum(sz); cl <- rep(seq_len(G), times = sz)
     alpha <- rnorm(G, 0, 1)[cl]; nu <- rnorm(N, 0, 1); eta <- matrix(rnorm(G * 4L, 0, 1.5), G, 4L)
@@ -77,7 +82,7 @@ test_that("analytical clustered SE flows through aggte at all levels (simple/gro
     a_cl  <- suppressWarnings(aggte(res_cl,  type = ty, bstrap = FALSE))
     a_iid <- suppressWarnings(aggte(res_iid, type = ty, bstrap = FALSE))
     expect_true(is.finite(a_cl$overall.se) && a_cl$overall.se > 0)
-    # clustered overall SE differs from the i.i.d. one under within-cluster correlation
+    # clustered overall SE differs from the i.i.d. one when units within a cluster are dependent
     expect_gt(abs(a_cl$overall.se - a_iid$overall.se) / a_iid$overall.se, 0.02)
   }
 })

--- a/tests/testthat/test-cluster-analytic.R
+++ b/tests/testthat/test-cluster-analytic.R
@@ -1,0 +1,83 @@
+# Analytical (no-bootstrap) cluster-robust standard errors. With a cluster variable and bstrap = FALSE,
+# att_gt() and aggte() report the cluster-robust variance (cluster sums of the influence function), the
+# same cluster-sum aggregation as the multiplier bootstrap (Callaway & Sant'Anna 2021, Remark 10).
+library(testthat)
+
+# panel with cluster-by-time shocks -> genuine within-cluster correlation in the (first-differenced) IF
+.make_clustered_shocks <- function(seed, G = 50L) {
+  set.seed(seed)
+  sz <- rep(c(1L, 2L, 4L, 10L), length.out = G); N <- sum(sz); cl <- rep(seq_len(G), times = sz)
+  alpha <- rnorm(G, 0, 1)[cl]; nu <- rnorm(N, 0, 1); per <- 1:4
+  eta <- matrix(rnorm(G * 4L, 0, 1.5), G, 4L)                     # cluster-by-time shocks
+  g <- sample(c(2L, 3L, 0L), G, replace = TRUE, prob = c(.34, .33, .33))[cl]  # cluster-level treatment
+  d <- data.frame(id = rep(seq_len(N), each = 4L), t = rep(per, N), cl = rep(cl, each = 4L),
+                  g = rep(g, each = 4L), a = rep(alpha, each = 4L), nu = rep(nu, each = 4L))
+  d$y <- d$a + d$nu + 0.3 * d$t + eta[cbind(d$cl, d$t)] + (d$g != 0L & d$t >= d$g) + rnorm(nrow(d))
+  d[order(d$id, d$t), ]
+}
+
+test_that("analytical (no-bootstrap) clustered SE for att_gt equals the cluster-sum CRVE", {
+  d <- .make_clustered_shocks(404L)
+  res <- att_gt(yname = "y", tname = "t", idname = "id", gname = "g", data = d,
+                control_group = "nevertreated", bstrap = FALSE, clustervars = "cl", base_period = "varying")
+  cv <- res$DIDparams$cluster_vector
+  skip_if_not(!is.null(cv) && length(cv) == nrow(res$inffunc), "cluster_vector not available/aligned")
+  n <- nrow(res$inffunc)
+  S <- rowsum(as.matrix(res$inffunc), cv)            # n_clusters x k cluster sums
+  se_target <- sqrt(colSums(S^2)) / n                 # cluster-sum CRVE per ATT(g,t)
+  ok <- is.finite(res$se) & is.finite(se_target)
+  # analytical => deterministic => exact match (no Monte Carlo tolerance needed)
+  expect_equal(unname(res$se[ok]), unname(se_target[ok]), tolerance = 1e-8)
+
+  # and it differs from the i.i.d. SE under within-cluster correlation
+  res_iid <- att_gt(yname = "y", tname = "t", idname = "id", gname = "g", data = d,
+                    control_group = "nevertreated", bstrap = FALSE, base_period = "varying")
+  k <- which(res$group == 2L & res$t == 2L)
+  expect_gt(abs(res$se[k] - res_iid$se[k]) / res_iid$se[k], 0.05)
+})
+
+test_that("analytical cluster SE agrees with the bootstrap cluster SE (multiple DGPs)", {
+  skip_on_cran()  # bootstrap-heavy
+  # cluster-by-time shocks; treatment at the cluster level (within = FALSE) or within clusters (TRUE).
+  mk <- function(seed, within, G = 60L) {
+    set.seed(seed); sz <- rep(c(1L, 2L, 4L, 10L), length.out = G); N <- sum(sz); cl <- rep(seq_len(G), times = sz)
+    alpha <- rnorm(G, 0, 1)[cl]; nu <- rnorm(N, 0, 1); eta <- matrix(rnorm(G * 4L, 0, 1.5), G, 4L)
+    g <- if (within) sample(c(2L, 3L, 0L), N, replace = TRUE, prob = c(.34, .33, .33))
+         else sample(c(2L, 3L, 0L), G, replace = TRUE, prob = c(.34, .33, .33))[cl]
+    d <- data.frame(id = rep(seq_len(N), each = 4L), t = rep(1:4, N), cl = rep(cl, each = 4L),
+                    g = rep(g, each = 4L), a = rep(alpha, each = 4L), nu = rep(nu, each = 4L))
+    d$y <- d$a + d$nu + 0.3 * d$t + eta[cbind(d$cl, d$t)] + (d$g != 0L & d$t >= d$g) + rnorm(nrow(d))
+    d[order(d$id, d$t), ]
+  }
+  for (within in c(FALSE, TRUE)) {
+    d <- mk(11L, within)
+    ra <- att_gt(yname="y", tname="t", idname="id", gname="g", data=d, control_group="nevertreated",
+                 bstrap=FALSE, clustervars="cl", base_period="varying")
+    rb <- att_gt(yname="y", tname="t", idname="id", gname="g", data=d, control_group="nevertreated",
+                 bstrap=TRUE, biters=3000L, clustervars="cl", pl=FALSE, cband=FALSE, base_period="varying", seed=11L)
+    k <- which(ra$group == 2L & ra$t == 2L)
+    # the reported bootstrap SE (IQR scale) is within a few percent of the analytical at this G
+    expect_lt(abs(rb$se[k] - ra$se[k]) / ra$se[k], 0.15)
+    # the bootstrap's own SD scale matches the analytical closely (same cluster variance)
+    dp <- ra$DIDparams; dp$biters <- 3000L; dp$pl <- FALSE
+    set.seed(11L); bo <- mboot(as.matrix(ra$inffunc)[, k, drop = FALSE], dp)
+    sd_se <- sd(as.numeric(bo$bres)) * sqrt(length(unique(dp$cluster_vector))) / nrow(ra$inffunc)
+    expect_lt(abs(sd_se - ra$se[k]) / ra$se[k], 0.06)
+  }
+})
+
+test_that("analytical clustered SE flows through aggte at all levels (simple/group/dynamic)", {
+  d <- .make_clustered_shocks(505L)
+  res_cl  <- att_gt(yname = "y", tname = "t", idname = "id", gname = "g", data = d,
+                    control_group = "nevertreated", bstrap = FALSE, clustervars = "cl", base_period = "varying")
+  res_iid <- att_gt(yname = "y", tname = "t", idname = "id", gname = "g", data = d,
+                    control_group = "nevertreated", bstrap = FALSE, base_period = "varying")
+  skip_if_not(!is.null(res_cl$DIDparams$cluster_vector), "cluster_vector not available")
+  for (ty in c("simple", "group", "dynamic")) {
+    a_cl  <- suppressWarnings(aggte(res_cl,  type = ty, bstrap = FALSE))
+    a_iid <- suppressWarnings(aggte(res_iid, type = ty, bstrap = FALSE))
+    expect_true(is.finite(a_cl$overall.se) && a_cl$overall.se > 0)
+    # clustered overall SE differs from the i.i.d. one under within-cluster correlation
+    expect_gt(abs(a_cl$overall.se - a_iid$overall.se) / a_iid$overall.se, 0.02)
+  }
+})

--- a/tests/testthat/test-error-handling.R
+++ b/tests/testthat/test-error-handling.R
@@ -62,12 +62,17 @@ test_that("att_gt messages about anticipation", {
   )
 })
 
-test_that("att_gt warns on clustered SE without bootstrap", {
-  expect_warning(
-    att_gt(yname = "Y", data = data_eh, tname = "period", idname = "id",
-           gname = "G", clustervars = "id", bstrap = FALSE),
-    "Clustered standard errors require"
+test_that("att_gt computes clustered SEs without the bootstrap (no 'requires bootstrap' warning)", {
+  # Clustering at the individual level (idname) without the bootstrap returns the unit-level analytical
+  # standard errors -- no "requires bootstrap" warning. A coarser cluster variable yields the analytical
+  # cluster-robust SE (covered in test-cluster-analytic.R).
+  w <- capture_warnings(
+    res <- att_gt(yname = "Y", data = data_eh, tname = "period", idname = "id",
+                  gname = "G", clustervars = "id", bstrap = FALSE)
   )
+  expect_false(any(grepl("Clustered standard errors require", w)))
+  expect_false(any(grepl("could not be computed analytically", w)))
+  expect_true(any(is.finite(res$se)))
 })
 
 # =============================================================================

--- a/tests/testthat/test-mboot-cluster.R
+++ b/tests/testthat/test-mboot-cluster.R
@@ -32,7 +32,7 @@ test_that("clustered mboot SE matches the cluster-sum (Remark 10) for UNBALANCED
                 control_group = "nevertreated", bstrap = TRUE, biters = 5000L,
                 clustervars = "cl", pl = FALSE, cband = FALSE, base_period = "varying")
   tg <- .cluster_targets(res)
-  skip_if_not(tg$ok, "cluster_vector not aligned with influence function")
+  expect_true(tg$ok)  # cluster_vector must be present and aligned with the influence-function rows
   # cluster-sum and cluster-mean genuinely differ when clusters are unbalanced
   expect_gt(abs(tg$sum - tg$mean) / tg$mean, 0.05)
   # reported SE tracks the cluster-SUM target (within bootstrap Monte Carlo tolerance) ...
@@ -48,7 +48,7 @@ test_that("clustered mboot SE is unchanged for BALANCED clusters (cluster-sum ==
                 control_group = "nevertreated", bstrap = TRUE, biters = 5000L,
                 clustervars = "cl", pl = FALSE, cband = FALSE, base_period = "varying")
   tg <- .cluster_targets(res)
-  skip_if_not(tg$ok, "cluster_vector not aligned with influence function")
+  expect_true(tg$ok)  # cluster_vector must be present and aligned with the influence-function rows
   expect_equal(tg$sum, tg$mean, tolerance = 1e-8)            # identical targets when balanced
   expect_equal(unname(res$se[tg$k]), tg$sum, tolerance = 0.08)
 })

--- a/tests/testthat/test-mboot-cluster.R
+++ b/tests/testthat/test-mboot-cluster.R
@@ -1,0 +1,63 @@
+# Cluster-robust multiplier bootstrap (Callaway & Sant'Anna 2021, Remark 10): the clustered standard
+# error aggregates the influence function to cluster *sums*. For equal-sized clusters this coincides with
+# the previous cluster-mean aggregation; for unbalanced clusters and repeated cross-sections it follows
+# the cluster-sum form that aligns with the (1/n) empirical average defining the estimator.
+library(testthat)
+
+# small staggered panel with within-cluster correlation; bal controls equal vs unequal cluster sizes
+.make_clustered <- function(seed, bal, G = 40L) {
+  set.seed(seed)
+  sz <- if (bal) rep(4L, G) else rep(c(1L, 2L, 3L, 8L), length.out = G)
+  N <- sum(sz); cl <- rep(seq_len(G), times = sz)
+  a <- rnorm(G, 0, 1)[cl]; nu <- rnorm(N, 0, 1); g <- ifelse(runif(N) < 0.5, 2L, 0L)
+  d <- data.frame(id = rep(seq_len(N), each = 3L), t = rep(1:3, N), cl = rep(cl, each = 3L),
+                  g = rep(g, each = 3L), a = rep(a, each = 3L), nu = rep(nu, each = 3L))
+  d$y <- d$a + d$nu + 0.5 * d$t + (d$g == 2L & d$t >= 2L) + rnorm(nrow(d))
+  d[order(d$id, d$t), ]
+}
+
+.cluster_targets <- function(res) {  # analytical cluster-SUM and cluster-MEAN for att(2,2)
+  k <- which(res$group == 2L & res$t == 2L)
+  cv <- res$DIDparams$cluster_vector
+  inf <- as.matrix(res$inffunc)[, k]; n <- nrow(res$inffunc)
+  S <- as.numeric(rowsum(matrix(inf, ncol = 1L), cv))
+  nc <- as.numeric(table(cv)); Gc <- length(S)
+  list(k = k, sum = sqrt(sum(S^2)) / n, mean = sqrt(sum((S / nc)^2)) / Gc, ok = length(cv) == n)
+}
+
+test_that("clustered mboot SE matches the cluster-sum (Remark 10) for UNBALANCED clusters", {
+  d <- .make_clustered(101L, bal = FALSE)
+  res <- att_gt(yname = "y", tname = "t", idname = "id", gname = "g", data = d,
+                control_group = "nevertreated", bstrap = TRUE, biters = 5000L,
+                clustervars = "cl", pl = FALSE, cband = FALSE, base_period = "varying")
+  tg <- .cluster_targets(res)
+  skip_if_not(tg$ok, "cluster_vector not aligned with influence function")
+  # cluster-sum and cluster-mean genuinely differ when clusters are unbalanced
+  expect_gt(abs(tg$sum - tg$mean) / tg$mean, 0.05)
+  # reported SE tracks the cluster-SUM target (within bootstrap Monte Carlo tolerance) ...
+  expect_equal(unname(res$se[tg$k]), tg$sum, tolerance = 0.08)
+  # ... and is clearly NOT the cluster-mean
+  expect_gt(abs(res$se[tg$k] - tg$mean) / tg$mean, 0.05)
+})
+
+test_that("clustered mboot SE is unchanged for BALANCED clusters (cluster-sum == cluster-mean)", {
+  d <- .make_clustered(202L, bal = TRUE)
+  res <- att_gt(yname = "y", tname = "t", idname = "id", gname = "g", data = d,
+                control_group = "nevertreated", bstrap = TRUE, biters = 5000L,
+                clustervars = "cl", pl = FALSE, cband = FALSE, base_period = "varying")
+  tg <- .cluster_targets(res)
+  skip_if_not(tg$ok, "cluster_vector not aligned with influence function")
+  expect_equal(tg$sum, tg$mean, tolerance = 1e-8)            # identical targets when balanced
+  expect_equal(unname(res$se[tg$k]), tg$sum, tolerance = 0.08)
+})
+
+test_that("clustering validation is preserved (at most one cluster variable beyond idname)", {
+  d <- .make_clustered(303L, bal = FALSE); d$cl2 <- d$cl
+  # two clustering variables (neither is idname) must still be rejected after the cluster-sum change
+  expect_error(
+    att_gt(yname = "y", tname = "t", idname = "id", gname = "g", data = d,
+           control_group = "nevertreated", bstrap = TRUE, biters = 99L,
+           clustervars = c("cl", "cl2"), pl = FALSE, cband = FALSE, base_period = "varying"),
+    regexp = "length 1|character scalar|clustervars|[Aa]t most one cluster"
+  )
+})

--- a/tests/testthat/test-mboot-cluster.R
+++ b/tests/testthat/test-mboot-cluster.R
@@ -4,7 +4,7 @@
 # the cluster-sum form that aligns with the (1/n) empirical average defining the estimator.
 library(testthat)
 
-# small staggered panel with within-cluster correlation; bal controls equal vs unequal cluster sizes
+# small staggered panel with units grouped into clusters; bal controls equal vs unequal cluster sizes
 .make_clustered <- function(seed, bal, G = 40L) {
   set.seed(seed)
   sz <- if (bal) rep(4L, G) else rep(c(1L, 2L, 3L, 8L), length.out = G)
@@ -26,6 +26,7 @@ library(testthat)
 }
 
 test_that("clustered mboot SE matches the cluster-sum (Remark 10) for UNBALANCED clusters", {
+  skip_on_cran()  # bootstrap-heavy (biters = 5000)
   d <- .make_clustered(101L, bal = FALSE)
   res <- att_gt(yname = "y", tname = "t", idname = "id", gname = "g", data = d,
                 control_group = "nevertreated", bstrap = TRUE, biters = 5000L,
@@ -41,6 +42,7 @@ test_that("clustered mboot SE matches the cluster-sum (Remark 10) for UNBALANCED
 })
 
 test_that("clustered mboot SE is unchanged for BALANCED clusters (cluster-sum == cluster-mean)", {
+  skip_on_cran()  # bootstrap-heavy (biters = 5000)
   d <- .make_clustered(202L, bal = TRUE)
   res <- att_gt(yname = "y", tname = "t", idname = "id", gname = "g", data = d,
                 control_group = "nevertreated", bstrap = TRUE, biters = 5000L,


### PR DESCRIPTION
## Summary

This brings the clustered standard errors in `did` in line with Callaway & Sant'Anna (2021, *Journal of
Econometrics*), **Remark 10**.

In the paper's framework the data are an i.i.d. sample of cross-sectional **units** {W_i} (individuals in a
panel, observations in repeated cross sections), with large n and **fixed T**. Estimation yields a
per-unit influence function ψ(W_i), with √n(θ̂ − θ) = n^(−1/2) Σ_i ψ(W_i) + o_p(1) and Σ = E[ψ(W) ψ(W)′].
The multiplier bootstrap (Algorithm 1, eq. 4.6) perturbs the estimate with i.i.d. **per-unit** multipliers.
**Remark 10** states that, to reflect cluster-based sampling uncertainty, one draws **cluster-specific**
multipliers instead of unit-specific ones — equivalently, the per-unit influence function is aggregated to
**cluster sums** before it is perturbed. This PR makes both the bootstrap and the analytical standard
errors do exactly that. There is no time dimension to the clustering: T is fixed and the within-unit time
structure is already contained in ψ(W_i).

## Changes

**1. Multiplier bootstrap (`mboot`).** With a cluster variable (beyond `idname`), the bootstrap draws one
multiplier per cluster and applies it to the cluster sums of the per-unit influence function (Remark 10).
For equal-sized clusters this is numerically identical to the previous implementation; for unbalanced
clusters it is the cluster-sum form. The unclustered (i.i.d., per-unit) bootstrap path is unchanged.

**2. Analytical clustered standard errors (no bootstrap).** With a cluster variable and `bstrap = FALSE`,
`att_gt()` and `aggte()` report the cluster-robust variance computed analytically from the cluster sums of
the per-unit influence function, at every aggregation level (group-time, overall/simple, group, dynamic,
calendar). Previously `bstrap = FALSE` returned the i.i.d. (per-unit) standard errors regardless of the
cluster variable. The pre-test Wald statistic is reported under clustering in this case, since its variance
matrix is now cluster-robust. Clustering on `idname` alone is the unit-level i.i.d. standard error.

## Evidence (Monte Carlo coverage, nominal 0.95)

Coverage was evaluated on data in which the sampling units within a cluster are **dependent** — so the
independent sampling unit is the cluster, not the individual unit — which is the case Remark 10 addresses.

*Multiplier bootstrap, coverage of a known att(g,t):*

| design | equal-sized clusters | unbalanced clusters |
|---|---|---|
| balanced panel | unchanged | restored to ≈ 0.95 |
| repeated cross sections | unchanged | restored to ≈ 0.95 |

*Analytical standard errors, att(g,t) and all aggregation levels:*

| design | per-unit i.i.d. (previous) | cluster-robust (this PR) |
|---|---|---|
| panel | 0.54–0.71 | 0.90–0.97 |
| repeated cross sections | 0.86–0.96 | 0.92–0.98 |

## Agreement between the analytical and bootstrap standard errors

Both target the same cluster-robust variance. Across several data-generating processes and cluster counts
(50–800 clusters, 20{,}000 bootstrap draws), the analytical standard error matches the bootstrap's
covariance-of-draws scale to ≈ 0.5%, and the reported bootstrap standard error (which uses `mboot`'s
interquartile-range scale) converges to the analytical value as the number of clusters grows — within
≈ 0.6% at 800 clusters. A regression test checks this agreement.

## Preserved behavior

The unclustered (i.i.d.) paths are unchanged, and all clustering input checks are retained (numeric
`clustervars`, at most one cluster dimension beyond `idname`, cluster-variable time-invariance). The
`att_gt` and `aggte` documentation is updated accordingly.

## Tests

`test-mboot-cluster.R` and `test-cluster-analytic.R`: the clustered bootstrap and analytical standard
errors use the cluster-sum form (and are unchanged for equal-sized clusters); the analytical att(g,t)
standard error equals the cluster-robust variance exactly; the clustered standard error flows through
`aggte` at every level; the analytical and bootstrap standard errors agree across DGPs; and the
cluster-dimension limit still errors. The full test suite passes.
