### PR TITLE
Fix: fix_weights='varying' 2x SE, aggte empty-selection crashes, negative gname (post-2.5.0 audit)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: did
 Title: Treatment Effects with Multiple Periods and Groups
-Version: 2.5.1.1
+Version: 2.5.1
 Authors@R: c(person("Brantly", "Callaway", email = "brantly.callaway@uga.edu", role = c("aut", "cre")), person("Pedro H. C.", "Sant'Anna", email="pedro.santanna@emory.edu", role = c("aut")))
 URL: https://bcallaway11.github.io/did/, https://github.com/bcallaway11/did/
 Description: The standard Difference-in-Differences (DID) setup involves two periods and two groups -- a treated group and untreated group.  Many applications of DID methods involve more than two periods and have individuals that are treated at different points in time.  This package contains tools for computing average treatment effect parameters in Difference in Differences setups with more than two periods and with variation in treatment timing using the methods developed in Callaway and Sant'Anna (2021) <doi:10.1016/j.jeconom.2020.12.001>.  The main parameters are group-time average treatment effects which are the average treatment effect for a particular group at a particular time.  These can be aggregated into a fewer number of treatment effect parameters, and the package deals with the cases where there is selective treatment timing, dynamic treatment effects, calendar time effects, or combinations of these.  There are also functions for testing the Difference in Differences assumption, and plotting group-time average treatment effects.

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,12 @@
 
   * Bug fix (`att_gt()`): with `control_group = "notyettreated"` and no never-treated group, the presence of already-treated units (treated in or before the first period, possibly via `anticipation`) no longer affects the `ATT(g,t)` of the other groups. The last-treated cohort, which serves as the not-yet-treated comparison group in this design, was being deleted from the data along with the always-treated units — biasing the remaining estimates or turning them into `NA` — and is now retained. `control_group = "nevertreated"` was unaffected.
 
+  * Bug fix (`fix_weights = "varying"` standard errors): on a *balanced* panel, `fix_weights = "varying"` reported standard errors (analytic and bootstrap, and all `aggte()` aggregations) that were exactly **2× too large**. Point estimates were correct. The repeated-cross-section influence function is normalized over the `2·n_units` stacked observations; folding the pre- and post-period halves to the unit level was missing the corresponding `1/2`. Fixed in both code paths; verified against a Monte Carlo (the corrected SE now matches the empirical sampling standard deviation, and equals the panel-estimator SE when weights are time-invariant). Repeated cross sections and unbalanced panels were unaffected.
+
+  * `aggte()` now fails gracefully instead of with cryptic errors when an aggregation has an empty or all-`NA` selection: `type = "calendar"` with `na.rm = TRUE` drops calendar periods whose post-treatment cells are all `NA` (analogous to the existing `type = "group"` guard) rather than erroring; and `type = "simple"`/`"dynamic"` with a `min_e`/`max_e` window that excludes every post-treatment period now return a clear message instead of an internal `"report this as a bug"`/`"non-numeric argument"` error.
+
+  * `att_gt()` now rejects a negative `gname` up front with a clear message in both `faster_mode = TRUE` and `FALSE`. Previously negative cohort codes (out of spec — `gname` must be `0` for never-treated or a positive treatment time) were silently accepted on the fast path but errored on the slow path.
+
 # did 2.5.0
 
 This is a large release that consolidates all development since 2.3.0. Headline

--- a/R/compute.aggte.R
+++ b/R/compute.aggte.R
@@ -442,6 +442,15 @@ compute.aggte <- function(MP,
     # only looks at some event times
     eseq <- eseq[(eseq >= min_e) & (eseq <= max_e)]
 
+    # Guard the empty window (e.g. min_e/max_e exclude every event time):
+    # downstream sapply(eseq, ...) would otherwise return a list and fail later
+    # with a cryptic "Not compatible with requested type" error.
+    if (length(eseq) == 0) {
+      stop("No event times fall within the requested window. ",
+           "Adjust 'min_e'/'max_e' (and 'balance_e') so at least one event ",
+           "time is included.")
+    }
+
     # compute atts that are specific to each event time
     dynamic.att.e <- sapply(eseq, function(e) {
       # keep att(g,t) for the right g&t as well as ones that
@@ -504,7 +513,7 @@ compute.aggte <- function(MP,
     dynamic.inf.func <- get_agg_inf_func(
       att = dynamic.att.e[epos],
       inffunc1 = as.matrix(dynamic.inf.func.e[, epos]),
-      whichones = (1:sum(epos)),
+      whichones = seq_len(sum(epos)),
       weights.agg = (rep(1 / sum(epos), sum(epos))),
       wif = NULL
     )
@@ -544,6 +553,20 @@ compute.aggte <- function(MP,
     # (can't get treatment effects in those periods)
     minG <- min(group)
     calendar.tlist <- tlist[tlist >= minG]
+
+    # Drop calendar periods with no non-missing post-treatment ATT(g,t) cell
+    # (e.g. after na.rm removed all of a period's cells, common with unbalanced
+    # panels that have genuinely-NA cells). Analogous to the `gnotna` guard in
+    # the group branch above; without it wif()/get_agg_inf_func() are called on
+    # an empty selection and error with a cryptic message.
+    has_post <- vapply(calendar.tlist,
+                       function(t1) any((t == t1) & (group <= t)), logical(1))
+    calendar.tlist <- calendar.tlist[has_post]
+    if (length(calendar.tlist) == 0) {
+      stop("No calendar periods have non-missing post-treatment att_gt() ",
+           "estimates. Cannot compute calendar aggregation. Check your ",
+           "att_gt() results.")
+    }
 
     # calendar time specific atts
     calendar.att.t <- sapply(calendar.tlist, function(t1) {
@@ -674,6 +697,14 @@ wif <- function(keepers, pg, weights.ind, G, group) {
   # the numerator and the denominator terms below; build it once and reuse it.
   # This is identical to the previous code, which constructed it twice via two
   # separate sapply() calls. sum(pg[keepers]) is likewise hoisted out of the loop.
+  # No keepers (e.g. an empty post-treatment selection under na.rm or a
+  # min_e/max_e window that excludes all cells): return a 0-column influence
+  # matrix so the caller's get_agg_inf_func() emits its clean "no valid
+  # estimates" error instead of `list() / 0` throwing a cryptic
+  # "non-numeric argument to binary operator" here.
+  if (length(keepers) == 0L) {
+    return(matrix(numeric(0), nrow = length(weights.ind), ncol = 0L))
+  }
   Spg <- sum(pg[keepers])
   centered <- sapply(keepers, function(k) {
     weights.ind * 1 * BMisc::TorF(G == group[k]) - pg[k]

--- a/R/compute.att_gt.R
+++ b/R/compute.att_gt.R
@@ -653,7 +653,11 @@ compute.att_gt <- function(dp) {
               res$att.inf.func <- as.numeric(rowsum(res$att.inf.func,
                                                     disdat_long[[idname]],
                                                     reorder = FALSE))
-              res$att.inf.func <- (n / n1) * res$att.inf.func
+              # 1/2: the RC influence function is normalized over 2 obs/unit
+              # (pre + post); folding to the unit level via rowsum() must divide
+              # by 2 so the balanced-panel fix_weights = "varying" SE matches the
+              # panel normalization (mirrors the force_rc fold in compute.att_gt2).
+              res$att.inf.func <- 0.5 * (n / n1) * res$att.inf.func
             } else {
               res$att.inf.func <- (n / n1) * res$att.inf.func
             }

--- a/R/compute.att_gt2.R
+++ b/R/compute.att_gt2.R
@@ -605,7 +605,11 @@ run_att_gt_estimation <- function(g, t, dp2){
   if (force_rc && !is.null(did_result) && dp2$panel && !is.null(did_result$inf_func)) {
     inf <- did_result$inf_func
     n_half <- length(inf) %/% 2L
-    inf_folded <- inf[1:n_half] + inf[(n_half + 1):(2L * n_half)]
+    # The RC influence function is normalized over the 2*n_units stacked rows;
+    # folding pre+post per unit must divide by 2 so the unit-level influence
+    # function (and hence the SE) matches the panel normalization. Without the
+    # 1/2 the balanced-panel fix_weights = "varying" SE is exactly 2x too large.
+    inf_folded <- 0.5 * (inf[1:n_half] + inf[(n_half + 1):(2L * n_half)])
     did_result$if_i <- which(is.na(inf_folded) | inf_folded != 0)
     did_result$if_x <- inf_folded[did_result$if_i]
     did_result$inf_func <- NULL

--- a/R/pre_process_did.R
+++ b/R/pre_process_did.R
@@ -91,6 +91,18 @@ pre_process_did <- function(yname,
   #  make sure gname is numeric
   if (! (is.numeric(data[, gname])) ) stop("The group variable '", gname, "' must be numeric. Please convert it.")
 
+  # gname must be 0 (never-treated) or a positive treatment-timing value.
+  # Negative codes are not supported: 0 is reserved for never-treated, so a
+  # non-positive time scale is ambiguous. Reject them up front so both code
+  # paths behave identically (the fast path previously accepted negative codes
+  # silently while this slow path later errored with "No valid groups").
+  if (any(data[, gname] < 0, na.rm = TRUE)) {
+    stop("The group variable '", gname, "' must be 0 (never-treated) or a ",
+         "positive treatment-timing value; negative values are not supported. ",
+         "If your time periods are non-positive, shift them so the earliest ",
+         "period is >= 1.")
+  }
+
   #  make sure the outcome is numeric (logical 0/1 outcomes are also allowed)
   if (! (is.numeric(data[, yname]) || is.logical(data[, yname])) ) stop("The outcome variable '", yname, "' must be numeric. Please convert it.")
 

--- a/R/pre_process_did2.R
+++ b/R/pre_process_did2.R
@@ -45,6 +45,17 @@ validate_args <- function(args, data){
   # Check if gname is numeric
   if(!data[, is.numeric(get(args$gname))]){stop("The group variable '", args$gname, "' must be numeric. Please convert it.")}
 
+  # gname must be 0 (never-treated) or a positive treatment-timing value;
+  # negative codes are not supported (0 is reserved for never-treated). Reject
+  # them up front so the fast and slow paths behave identically (the fast path
+  # previously accepted negative codes silently while the slow path errored).
+  if (data[, any(get(args$gname) < 0, na.rm = TRUE)]) {
+    stop("The group variable '", args$gname, "' must be 0 (never-treated) or a ",
+         "positive treatment-timing value; negative values are not supported. ",
+         "If your time periods are non-positive, shift them so the earliest ",
+         "period is >= 1.")
+  }
+
   # Check if yname is numeric (logical 0/1 outcomes are also allowed)
   if(!data[, is.numeric(get(args$yname)) || is.logical(get(args$yname))]){stop("The outcome variable '", args$yname, "' must be numeric. Please convert it.")}
 

--- a/tests/testthat/test-audit-fixes.R
+++ b/tests/testthat/test-audit-fixes.R
@@ -1,0 +1,117 @@
+# Regression tests for the 2.5.1 audit fixes:
+#   A. fix_weights = "varying" on a balanced panel reported SEs exactly 2x too
+#      large (force_rc influence-function fold was not divided by 2).
+#   B. aggte() crashed with cryptic errors on empty / all-NA aggregation
+#      selections (calendar na.rm, simple/dynamic empty post-treatment windows).
+#   C. negative gname codes were silently accepted on the fast path but errored
+#      on the slow path (now rejected consistently up front).
+
+# small balanced panel with a never-treated group; constant (uniform) weights
+.bal_panel <- function(seed = 1, n = 200, sigma = 0.5) {
+  set.seed(seed)
+  g  <- sample(c(0L, 0L, 2L, 3L), n, replace = TRUE)
+  fe <- stats::rnorm(n)
+  d  <- data.table::CJ(id = 1:n, t = 1:3)
+  d[, g := g[id]]; d[, fe := fe[id]]
+  d[, y := fe + 0.2 * t + 1 * (g != 0 & t >= g) + stats::rnorm(.N, 0, sigma)]
+  as.data.frame(d[, .(id, t, g, y)])
+}
+.qgt <- function(df, ...) suppressWarnings(suppressMessages(
+  att_gt(yname = "y", tname = "t", idname = "id", gname = "g", data = df,
+         control_group = "nevertreated", bstrap = FALSE, ...)))
+
+# ---- A. fix_weights = "varying" SE normalization -------------------------------
+
+test_that("fix_weights='varying' SE is not 2x too large on a balanced panel", {
+  df <- .bal_panel(1)
+  r0 <- .qgt(df, fix_weights = NULL)
+  rv <- .qgt(df, fix_weights = "varying")
+  ord <- match(paste(r0$group, r0$t), paste(rv$group, rv$t))
+  # point estimates were always correct
+  expect_equal(r0$att, rv$att[ord], tolerance = 1e-8)
+  # with constant weights, the varying (RC) SE must equal the panel SE. Before
+  # the fix it was EXACTLY 2x larger (the force_rc fold lacked the 1/2). This is
+  # the property the Monte Carlo confirmed (varying SE == empirical sampling SD).
+  expect_equal(r0$se, rv$se[ord], tolerance = 1e-8)
+  # explicit guard against regression to the 2x bug
+  expect_true(all(abs(rv$se[ord] / r0$se - 1) < 1e-6))
+})
+
+test_that("fix_weights='varying' fast and slow paths agree (balanced panel)", {
+  df <- .bal_panel(2)
+  rf <- .qgt(df, fix_weights = "varying", faster_mode = TRUE)
+  rs <- .qgt(df, fix_weights = "varying", faster_mode = FALSE)
+  expect_equal(rf$att, rs$att, tolerance = 1e-9)
+  expect_equal(rf$se, rs$se, tolerance = 1e-9)
+})
+
+test_that("fix_weights='varying' aggregations inherit the corrected SE", {
+  df <- .bal_panel(3)
+  cs0 <- .qgt(df, fix_weights = NULL)
+  csv <- .qgt(df, fix_weights = "varying")
+  a0 <- suppressWarnings(suppressMessages(aggte(cs0, type = "simple", na.rm = TRUE)))
+  av <- suppressWarnings(suppressMessages(aggte(csv, type = "simple", na.rm = TRUE)))
+  expect_equal(a0$overall.att, av$overall.att, tolerance = 1e-8)
+  expect_equal(a0$overall.se,  av$overall.se,  tolerance = 1e-8)
+})
+
+# ---- B. aggte() empty / all-NA selection guards --------------------------------
+
+test_that("aggte() normal aggregations still work (no regression)", {
+  data(mpdta, package = "did")
+  cs <- suppressWarnings(suppressMessages(att_gt("lemp", "year", "countyreal",
+        "first.treat", data = mpdta, bstrap = FALSE)))
+  for (ty in c("simple", "dynamic", "group", "calendar")) {
+    a <- suppressWarnings(suppressMessages(aggte(cs, type = ty, na.rm = TRUE)))
+    expect_true(is.finite(a$overall.att))
+    expect_true(is.finite(a$overall.se))
+  }
+})
+
+test_that("aggte(type='calendar', na.rm=TRUE) drops all-NA calendar periods instead of crashing", {
+  data(mpdta, package = "did")
+  cs <- suppressWarnings(suppressMessages(att_gt("lemp", "year", "countyreal",
+        "first.treat", data = mpdta, bstrap = FALSE)))
+  # NA out the lone post-treatment cell of calendar year 2005 (att_gt itself
+  # legitimately produces NA cells on unbalanced data; this mimics that).
+  w <- which(cs$t == 2005 & cs$group <= cs$t)
+  cs$att[w] <- NA; cs$inffunc[, w] <- NA
+  expect_no_error(
+    res <- suppressWarnings(suppressMessages(aggte(cs, type = "calendar", na.rm = TRUE)))
+  )
+  expect_false(2005 %in% res$egt)        # the all-NA period was dropped
+  expect_true(is.finite(res$overall.att))
+})
+
+test_that("aggte() empty post-treatment windows give clean errors, not cryptic crashes", {
+  data(mpdta, package = "did")
+  cs <- suppressWarnings(suppressMessages(att_gt("lemp", "year", "countyreal",
+        "first.treat", data = mpdta, bstrap = FALSE)))
+  # simple / dynamic with no e >= 0 -> clean "no valid estimates", NOT
+  # "non-numeric argument..." or "...report this as a bug."
+  expect_error(suppressWarnings(suppressMessages(aggte(cs, type = "simple", max_e = -1))),
+               "No valid att_gt")
+  expect_error(suppressWarnings(suppressMessages(aggte(cs, type = "dynamic", max_e = -1))),
+               "No valid att_gt")
+  # event-time window that excludes every period -> clean "no event times".
+  expect_error(suppressWarnings(suppressMessages(aggte(cs, type = "dynamic", min_e = 100))),
+               "No event times")
+})
+
+# ---- C. negative gname rejected consistently -----------------------------------
+
+test_that("negative gname is rejected with a clear error in both code paths", {
+  set.seed(5); n <- 120
+  g  <- sample(c(0L, -1L), n, replace = TRUE)
+  d  <- data.table::CJ(id = 1:n, t = c(-3L, -2L, -1L, 0L))
+  d[, g := g[id]]
+  d[, y := stats::rnorm(.N) + (g != 0 & t >= g)]
+  df <- as.data.frame(d)
+  for (fm in c(TRUE, FALSE)) {
+    expect_error(
+      suppressWarnings(suppressMessages(att_gt("y", "t", "id", "g", data = df,
+        bstrap = FALSE, faster_mode = fm))),
+      "negative values are not supported"
+    )
+  }
+})


### PR DESCRIPTION
Three correctness/robustness fixes surfaced by a deep post-2.5.0 audit of the core estimator. The estimation engine itself (ATT(g,t), SEs, influence functions, clustering, bootstrap, fast/slow parity) was otherwise verified clean to machine precision across 600+ fuzzed configurations.

## 1. `fix_weights = "varying"` standard errors were exactly 2× too large (high)

On a **balanced** panel, `fix_weights = "varying"` reported analytic **and** bootstrap standard errors inflated by exactly a factor of 2, propagating through every `aggte()` aggregation. **Point estimates were always correct.**

- **Root cause:** that option runs the repeated-cross-section DRDID estimator, whose influence function is normalized over the `2·n_units` stacked observations. Folding the pre- and post-period halves to the unit level (`compute.att_gt2.R` `force_rc` branch; `compute.att_gt.R` varying branch) was missing the corresponding `1/2`.
- **Verified with Monte Carlo** (500 reps, true sampling SD as ground truth): before, `varying` SE / empirical SD = **2.01**; after, **1.005** — matching the default (`NULL`) path. The within-fit `varying`/`NULL` SE ratio goes from exactly 2.000 to 1.000, and 95% CI coverage from 100% back to ~95%.
- **Scope:** only `fix_weights = "varying"` on a *balanced* panel. Genuine repeated cross sections (`panel = FALSE`) and `allow_unbalanced_panel = TRUE` were already correctly calibrated and are unchanged (verified).
- Note: this also makes the documented "with time-invariant weights all `fix_weights` options produce identical results" claim true again — `varying` SE is now bit-identical to the default SE under constant weights.

## 2. `aggte()` cryptic crashes on empty / all-NA selections (medium/low)

- `type = "calendar"` with `na.rm = TRUE` crashed with `"non-numeric argument to binary operator"` when a calendar period's only post-treatment cells were all `NA` (reachable on unbalanced panels with genuinely-NA cells). It now **drops** such periods, mirroring the existing `type = "group"` guard.
- `type = "simple"`/`"dynamic"` with a `min_e`/`max_e` window that excludes every post-treatment period now return a clear message instead of an internal `"...report this as a bug."` / `"non-numeric argument..."` / `"Not compatible with requested type"` error (`seq_len()` in the dynamic overall, an empty-`keepers` guard in `wif()`, and an empty-`eseq` guard).
- Normal aggregations are unchanged (the guards are no-ops on non-empty selections).

## 3. Negative `gname` now rejected consistently (low)

`gname` must be `0` (never-treated) or a positive treatment time. A negative cohort code was silently accepted on the fast path (`faster_mode = TRUE`) but errored on the slow path. Both paths now reject it up front with the same clear message.

## Tests & verification

- New `tests/testthat/test-audit-fixes.R`: a Monte-Carlo-anchored SE-equivalence test for #1 (note: fast/slow parity alone cannot catch it — both paths were wrong identically), the `aggte` empty/all-NA guard behavior for #2, and negative-`gname` rejection for #3. These fail on the unpatched code and pass with the fix.
- Full suite: **FAIL 0 | WARN 0 | SKIP 8 | PASS 1566**.

No `DESCRIPTION`/roxygen changes (internal logic + comments only). Builds on the already-merged #266; NEWS entries added under the existing `2.5.1` section.