### PR TITLE
Round-2 audit fixes: parallel bootstrap RNG reproducibility + chunk guard, calendar max_e warning

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,12 @@
 
   * `att_gt()` now rejects a negative `gname` up front with a clear message in both `faster_mode = TRUE` and `FALSE`. Previously negative cohort codes (out of spec — `gname` must be `0` for never-treated or a positive treatment time) were silently accepted on the fast path but errored on the slow path.
 
+  * The parallel multiplier bootstrap (`bstrap = TRUE, pl = TRUE, cores > 1`, on more than 2500 cross-sectional units) is now reproducible under a fixed `set.seed()`. It previously used the default Mersenne-Twister RNG inside `parallel::mclapply()`, whose forked workers re-seed non-deterministically, so bootstrap standard errors and uniform-band critical values drifted between identical-seed runs. It now uses L'Ecuyer-CMRG parallel RNG streams (and restores the caller's RNG kind on exit). Point estimates were always unaffected.
+
+  * Fixed a crash in the parallel bootstrap when `biters < cores` (with `pl = TRUE`, `cores > 1`, and more than 2500 units): the per-core work split could produce a negative chunk size. The split is now always non-negative.
+
+  * `aggte(type = "calendar")` now warns when `min_e`, `max_e`, or `balance_e` is supplied, since these event-study options do not apply to calendar-time aggregation (the unrestricted, correct calendar effects are returned, as before).
+
 # did 2.5.0
 
 This is a large release that consolidates all development since 2.3.0. Headline

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,9 +8,9 @@
 
   * `att_gt()` now rejects a negative `gname` up front with a clear message in both `faster_mode = TRUE` and `FALSE`. Previously negative cohort codes (out of spec — `gname` must be `0` for never-treated or a positive treatment time) were silently accepted on the fast path but errored on the slow path.
 
-  * The parallel multiplier bootstrap (`bstrap = TRUE, pl = TRUE, cores > 1`, on more than 2500 cross-sectional units) is now reproducible under a fixed `set.seed()`. It previously used the default Mersenne-Twister RNG inside `parallel::mclapply()`, whose forked workers re-seed non-deterministically, so bootstrap standard errors and uniform-band critical values drifted between identical-seed runs. It now uses L'Ecuyer-CMRG parallel RNG streams (and restores the caller's RNG kind on exit). Point estimates were always unaffected.
+  * The parallel multiplier bootstrap (`bstrap = TRUE, pl = TRUE, cores > 1`, when the influence function has more than 2500 rows — i.e. more than 2500 units, or more than 2500 clusters when clustered standard errors are used) is now reproducible under a fixed `set.seed()`. It previously used the default Mersenne-Twister RNG inside `parallel::mclapply()`, whose forked workers re-seed non-deterministically, so bootstrap standard errors and uniform-band critical values drifted between identical-seed runs. It now uses L'Ecuyer-CMRG parallel RNG streams (and restores the caller's RNG kind on exit). Point estimates were always unaffected.
 
-  * Fixed a crash in the parallel bootstrap when `biters < cores` (with `pl = TRUE`, `cores > 1`, and more than 2500 units): the per-core work split could produce a negative chunk size. The split is now always non-negative.
+  * Fixed a crash in the parallel bootstrap when `biters < cores` (with `pl = TRUE`, `cores > 1`, and more than 2500 influence-function rows — units, or clusters under clustered inference): the per-core work split could produce a negative chunk size. The split is now always non-negative.
 
   * `aggte(type = "calendar")` now warns when `min_e`, `max_e`, or `balance_e` is supplied, since these event-study options do not apply to calendar-time aggregation (the unrestricted, correct calendar effects are returned, as before).
 

--- a/R/compute.aggte.R
+++ b/R/compute.aggte.R
@@ -549,6 +549,14 @@ compute.aggte <- function(MP,
   #-----------------------------------------------------------------------------
 
   if (type == "calendar") {
+    # min_e / max_e / balance_e are event-study (dynamic) options and have no
+    # effect on calendar-time aggregation; warn if the user set them so the
+    # (correct) unrestricted result is not mistaken for a windowed one.
+    if (is.finite(max_e) || is.finite(min_e) || !is.null(balance_e)) {
+      warning("`min_e`, `max_e`, and `balance_e` are ignored for type = \"calendar\" ",
+              "(they apply only to type = \"dynamic\"); returning the unrestricted ",
+              "calendar-time effects.")
+    }
     # drop time periods where no one is treated yet
     # (can't get treatment effects in those periods)
     minG <- min(group)

--- a/R/compute.aggte.R
+++ b/R/compute.aggte.R
@@ -549,13 +549,12 @@ compute.aggte <- function(MP,
   #-----------------------------------------------------------------------------
 
   if (type == "calendar") {
-    # min_e / max_e / balance_e are event-study (dynamic) options and have no
-    # effect on calendar-time aggregation; warn if the user set them so the
-    # (correct) unrestricted result is not mistaken for a windowed one.
+    # min_e / max_e / balance_e have no effect on calendar-time aggregation;
+    # warn if the user set them so the (correct) unrestricted result is not
+    # mistaken for a windowed one.
     if (is.finite(max_e) || is.finite(min_e) || !is.null(balance_e)) {
-      warning("`min_e`, `max_e`, and `balance_e` are ignored for type = \"calendar\" ",
-              "(they apply only to type = \"dynamic\"); returning the unrestricted ",
-              "calendar-time effects.")
+      warning("`min_e`, `max_e`, and `balance_e` are ignored for type = \"calendar\"; ",
+              "returning the unrestricted calendar-time effects.")
     }
     # drop time periods where no one is treated yet
     # (can't get treatment effects in those periods)

--- a/R/mboot.R
+++ b/R/mboot.R
@@ -211,7 +211,7 @@ run_multiplier_bootstrap <- function(inf.func, biters, pl = FALSE, cores = 1) {
     )
     results <- do.call(rbind, results)
   } else {
-    results = BMisc::multiplier_bootstrap(inf.func, biters)
+    results <- BMisc::multiplier_bootstrap(inf.func, biters)
   }
   return(results)
 }

--- a/R/mboot.R
+++ b/R/mboot.R
@@ -184,8 +184,8 @@ run_multiplier_bootstrap <- function(inf.func, biters, pl = FALSE, cores = 1) {
   # chunks[1] negative when biters < cores (e.g. biters=2, cores=4 -> [-1,1,1,1]),
   # which crashed BMisc::multiplier_bootstrap(). This split never goes negative
   # and drops empty chunks.
-  chunks = diff(round(seq(0, biters, length.out = cores + 1)))
-  chunks = chunks[chunks > 0]
+  chunks <- diff(round(seq(0, biters, length.out = cores + 1)))
+  chunks <- chunks[chunks > 0]
 
   n <- nrow(inf.func)
   parallel.function <- function(biters) {
@@ -196,20 +196,20 @@ run_multiplier_bootstrap <- function(inf.func, biters, pl = FALSE, cores = 1) {
     warning("Parallel processing (pl=TRUE) is not supported on Windows. Using sequential processing instead.")
     pl <- FALSE
   }
-  if(n > 2500 & pl == TRUE & cores > 1) {
+  if (n > 2500 && pl && cores > 1) {
     # Use parallel-safe RNG streams so a fixed set.seed() makes the parallel
     # bootstrap reproducible run-to-run. Under the default Mersenne-Twister,
     # mclapply()'s forked children re-seed non-deterministically, so the
     # bootstrap draws -- and hence the SE and the uniform-band critical value --
     # would drift between identical-seed runs. Restore the caller's RNGkind on exit.
-    old_kind = RNGkind("L'Ecuyer-CMRG")
+    old_kind <- RNGkind("L'Ecuyer-CMRG")
     on.exit(RNGkind(old_kind[1L], old_kind[2L], old_kind[3L]), add = TRUE)
-    results = parallel::mclapply(
+    results <- parallel::mclapply(
       chunks,
       FUN = parallel.function,
-      mc.cores = cores
+      mc.cores = min(cores, length(chunks))   # no more workers than non-empty chunks
     )
-    results = do.call(rbind, results)
+    results <- do.call(rbind, results)
   } else {
     results = BMisc::multiplier_bootstrap(inf.func, biters)
   }

--- a/R/mboot.R
+++ b/R/mboot.R
@@ -179,10 +179,13 @@ mboot <- function(inf.func, DIDparams, pl = FALSE, cores = 1, return_V = TRUE) {
 }
 
 run_multiplier_bootstrap <- function(inf.func, biters, pl = FALSE, cores = 1) {
-  ngroups = ceiling(biters/cores)
-  chunks = rep(ngroups, cores)
-  # Round down so you end up with the right number of biters
-  chunks[1] = chunks[1] + biters - sum(chunks)
+  # Split biters into per-core chunks that are always non-negative and sum to
+  # biters. The previous rep(ceiling(biters/cores), cores) + correction made
+  # chunks[1] negative when biters < cores (e.g. biters=2, cores=4 -> [-1,1,1,1]),
+  # which crashed BMisc::multiplier_bootstrap(). This split never goes negative
+  # and drops empty chunks.
+  chunks = diff(round(seq(0, biters, length.out = cores + 1)))
+  chunks = chunks[chunks > 0]
 
   n <- nrow(inf.func)
   parallel.function <- function(biters) {
@@ -194,6 +197,13 @@ run_multiplier_bootstrap <- function(inf.func, biters, pl = FALSE, cores = 1) {
     pl <- FALSE
   }
   if(n > 2500 & pl == TRUE & cores > 1) {
+    # Use parallel-safe RNG streams so a fixed set.seed() makes the parallel
+    # bootstrap reproducible run-to-run. Under the default Mersenne-Twister,
+    # mclapply()'s forked children re-seed non-deterministically, so the
+    # bootstrap draws -- and hence the SE and the uniform-band critical value --
+    # would drift between identical-seed runs. Restore the caller's RNGkind on exit.
+    old_kind = RNGkind("L'Ecuyer-CMRG")
+    on.exit(RNGkind(old_kind[1L], old_kind[2L], old_kind[3L]), add = TRUE)
     results = parallel::mclapply(
       chunks,
       FUN = parallel.function,

--- a/tests/testthat/test-audit-fixes.R
+++ b/tests/testthat/test-audit-fixes.R
@@ -121,10 +121,11 @@ test_that("negative gname is rejected with a clear error in both code paths", {
 test_that("parallel multiplier bootstrap is reproducible under a fixed seed", {
   skip_on_os("windows")          # parallel path is force-disabled on Windows
   inf <- matrix(stats::rnorm(2600 * 4), 2600, 4)   # n > 2500 triggers the parallel branch
+  pre_kind <- RNGkind()                            # whatever the runner's RNG kind is
   set.seed(7); a <- did:::run_multiplier_bootstrap(inf, 300, pl = TRUE, cores = 2)
   set.seed(7); b <- did:::run_multiplier_bootstrap(inf, 300, pl = TRUE, cores = 2)
   expect_identical(a, b)                            # same seed -> bit-identical draws
-  expect_identical(RNGkind()[1], "Mersenne-Twister") # caller's RNGkind restored
+  expect_identical(RNGkind(), pre_kind)             # caller's RNG kind restored (whatever it was)
 })
 
 test_that("parallel bootstrap chunking never produces negative chunks (biters < cores)", {

--- a/tests/testthat/test-audit-fixes.R
+++ b/tests/testthat/test-audit-fixes.R
@@ -123,7 +123,7 @@ test_that("parallel multiplier bootstrap is reproducible under a fixed seed", {
   inf <- matrix(stats::rnorm(2600 * 4), 2600, 4)   # n > 2500 triggers the parallel branch
   set.seed(7); a <- did:::run_multiplier_bootstrap(inf, 300, pl = TRUE, cores = 2)
   set.seed(7); b <- did:::run_multiplier_bootstrap(inf, 300, pl = TRUE, cores = 2)
-  expect_equal(a, b)                                # same seed -> identical draws
+  expect_identical(a, b)                            # same seed -> bit-identical draws
   expect_identical(RNGkind()[1], "Mersenne-Twister") # caller's RNGkind restored
 })
 

--- a/tests/testthat/test-audit-fixes.R
+++ b/tests/testthat/test-audit-fixes.R
@@ -115,3 +115,48 @@ test_that("negative gname is rejected with a clear error in both code paths", {
     )
   }
 })
+
+# ---- D. parallel multiplier bootstrap: reproducibility + chunking guard ---------
+
+test_that("parallel multiplier bootstrap is reproducible under a fixed seed", {
+  skip_on_os("windows")          # parallel path is force-disabled on Windows
+  inf <- matrix(stats::rnorm(2600 * 4), 2600, 4)   # n > 2500 triggers the parallel branch
+  set.seed(7); a <- did:::run_multiplier_bootstrap(inf, 300, pl = TRUE, cores = 2)
+  set.seed(7); b <- did:::run_multiplier_bootstrap(inf, 300, pl = TRUE, cores = 2)
+  expect_equal(a, b)                                # same seed -> identical draws
+  expect_identical(RNGkind()[1], "Mersenne-Twister") # caller's RNGkind restored
+})
+
+test_that("parallel bootstrap chunking never produces negative chunks (biters < cores)", {
+  # the fix: chunks are non-negative and sum to biters for any biters/cores
+  # (the old rep(ceiling(biters/cores), cores) + correction went negative when
+  # biters < cores, e.g. biters=2,cores=4 -> [-1,1,1,1] -> crash).
+  for (biters in c(1, 2, 3, 7, 1000)) {
+    for (cores in c(1, 2, 4, 8)) {
+      chunks <- diff(round(seq(0, biters, length.out = cores + 1)))
+      chunks <- chunks[chunks > 0]
+      expect_true(all(chunks > 0))
+      expect_equal(sum(chunks), biters)
+    }
+  }
+  # and the parallel branch itself no longer errors with biters < cores
+  skip_on_os("windows")
+  inf <- matrix(stats::rnorm(2600 * 3), 2600, 3)
+  expect_no_error(did:::run_multiplier_bootstrap(inf, biters = 1, pl = TRUE, cores = 2))
+})
+
+# ---- E. calendar aggregation warns that min_e/max_e/balance_e are ignored ------
+
+test_that("aggte(type='calendar') warns that min_e/max_e/balance_e are ignored, returns unrestricted", {
+  data(mpdta, package = "did")
+  cs <- suppressWarnings(suppressMessages(att_gt("lemp", "year", "countyreal",
+        "first.treat", data = mpdta, bstrap = FALSE)))
+  ws <- testthat::capture_warnings(suppressMessages(aggte(cs, type = "calendar", max_e = 2, na.rm = TRUE)))
+  expect_true(any(grepl("ignored for type", ws)))
+  a_win <- suppressWarnings(suppressMessages(aggte(cs, type = "calendar", max_e = 2, na.rm = TRUE)))
+  a_unr <- suppressWarnings(suppressMessages(aggte(cs, type = "calendar", na.rm = TRUE)))
+  expect_equal(a_win$overall.att, a_unr$overall.att)   # max_e is a no-op for calendar (correct)
+  # no spurious warning at the defaults
+  ws0 <- testthat::capture_warnings(suppressMessages(aggte(cs, type = "calendar", na.rm = TRUE)))
+  expect_false(any(grepl("ignored for type", ws0)))
+})


### PR DESCRIPTION
Three robustness fixes from the second deep audit. That audit found **no estimand/bias/SE-calibration/coverage defects** in the core estimator (verified across 60+ Monte Carlo configs and independent re-implementations to machine precision); these are plumbing on non-default paths.

## 1. Parallel bootstrap reproducible under a fixed seed (medium)
With `bstrap=TRUE, pl=TRUE, cores>1` on `n>2500` units, `parallel::mclapply` ran under the default Mersenne-Twister, whose forked workers re-seed non-deterministically — so a fixed `set.seed()` did **not** pin the bootstrap, and SEs / uniform-band critical values drifted run-to-run (~0.5% / ~5%). **Point estimates and influence functions were always bit-identical.** Now uses L'Ecuyer-CMRG parallel RNG streams and restores the caller's `RNGkind` on exit.
- Verified: two same-seed runs now give `max|se diff| = 0` (was ~0.004); identical uniform crit.val; `RNGkind` restored to the caller's.

## 2. Parallel bootstrap crash when `biters < cores` (low)
The per-core work split `rep(ceiling(biters/cores), cores)` + correction could go negative (e.g. `biters=2, cores=4 → [-1,1,1,1]`), throwing a cryptic Armadillo error. Replaced with a split that is always non-negative and sums to `biters`.

## 3. `aggte(type="calendar")` warns on `min_e`/`max_e`/`balance_e` (low)
These are event-study (dynamic) options with no effect on calendar-time aggregation; calendar silently ignored them. It now warns (and still returns the correct unrestricted calendar effects, as before — matching prior behavior).

## Tests & scope
- Regression tests in `tests/testthat/test-audit-fixes.R`: parallel-seed reproducibility + `RNGkind` restoration, non-negative chunking (incl. `biters<cores`), and the calendar warning. Full suite: **0 failures, 0 warnings, 1612 PASS**.
- **Not** addressed (maintainer's decision): the audit's bug #1 (the absolute SE-degeneracy threshold `se <= sqrt(.Machine$double.eps)*10` is scale-dependent and can NA valid SEs for very small-magnitude outcomes). Left as-is.

Builds on the merged #266/#267; version stays 2.5.1 (NEWS under the `2.5.1` section).