### PR TITLE
Restore release version 2.5.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: did
 Title: Treatment Effects with Multiple Periods and Groups
-Version: 2.5.1.1
+Version: 2.5.1
 Authors@R: c(person("Brantly", "Callaway", email = "brantly.callaway@uga.edu", role = c("aut", "cre")), person("Pedro H. C.", "Sant'Anna", email="pedro.santanna@emory.edu", role = c("aut")))
 URL: https://bcallaway11.github.io/did/, https://github.com/bcallaway11/did/
 Description: The standard Difference-in-Differences (DID) setup involves two periods and two groups -- a treated group and untreated group.  Many applications of DID methods involve more than two periods and have individuals that are treated at different points in time.  This package contains tools for computing average treatment effect parameters in Difference in Differences setups with more than two periods and with variation in treatment timing using the methods developed in Callaway and Sant'Anna (2021) <doi:10.1016/j.jeconom.2020.12.001>.  The main parameters are group-time average treatment effects which are the average treatment effect for a particular group at a particular time.  These can be aggregated into a fewer number of treatment effect parameters, and the package deals with the cases where there is selective treatment timing, dynamic treatment effects, calendar time effects, or combinations of these.  There are also functions for testing the Difference in Differences assumption, and plotting group-time average treatment effects.


### PR DESCRIPTION
## Summary

- Restore `DESCRIPTION` from development version `2.5.1.1` to release version `2.5.1`.
- Keep the package on the published 2.5.1 release line.

## Cause

PR #271 was a release-site update but did not carry the repository's `release` label. The post-merge workflow therefore treated it as a regular development PR and created a separate version-bump commit.

## Safety

This PR changes only the `Version:` field in `DESCRIPTION`. It carries the `release` label so the post-merge development-version workflow will skip it.

## Validation

- Parsed `DESCRIPTION` successfully.
- Confirmed the exact version is `2.5.1`.
- Confirmed the diff contains one changed line in one file.
- `git diff --check` passes.