### PR TITLE
Re-check the never-treated group and the cohort list after balancing the panel

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# did 2.5.1.902
+
+  * Bug fix (`att_gt()`, balanced panel): the never-treated group is now re-checked after the panel is balanced. Balancing drops units whole, so a covariate missing in one period for every never-treated unit removed the whole group after the check had passed; every ATT(g,t) was then `NA` — silently under `faster_mode = TRUE`, and reported as "overlap condition violated" under `faster_mode = FALSE`. The last treated cohort is now used as the comparison group (as when the data contain no never-treated group), with a warning, and the estimates equal those from the balanced sample. Under `control_group = "notyettreated"` the last cohort's pre-treatment cells are no longer computed in this case (it is a comparison group only).
+
+  * Bug fix (`att_gt()`, balanced panel): a treated cohort that loses all of its units in balancing is now dropped with a warning; `faster_mode = TRUE` stopped with an internal error and `faster_mode = FALSE` returned `NA` for all of its cells.
+
+  * `att_gt()` now warns when a (g,t) cell has no treated or control units (`faster_mode = TRUE`) or when its estimate is `NaN` (both modes) instead of setting it to `NA` silently, and `faster_mode = FALSE` stores an integer `gname` as double, as `faster_mode = TRUE` does.
+
+  * Clearer errors when nothing can be estimated: no treated cohort left once the last cohort is used as the comparison group, no period left before its treatment date, a single period left, or a sample emptied by the missing-data drop. `aggte()` now says so when there is no post-treatment cell to aggregate.
+
 # did 2.5.1.901
 
   * **Behavior change** (`att_gt(panel = FALSE)`): a supplied `idname` must now be unique across *all* rows. `panel = FALSE` declares genuine repeated cross sections, in which every observation is a distinct sampling unit, so an `idname` that repeats (within or across periods) contradicts the requested data structure; it is now rejected up front with a message pointing at `panel = TRUE` / `allow_unbalanced_panel = TRUE` for data where the same units are observed in several periods, and at supplying an observation-level unique id — or omitting `idname` — for genuine repeated cross sections (a recurring household or region code can be passed through `clustervars` instead). `panel = TRUE` — including `allow_unbalanced_panel = TRUE` — is unaffected, and both `faster_mode = TRUE` and `FALSE` give the same error.

--- a/R/att_gt.R
+++ b/R/att_gt.R
@@ -172,7 +172,8 @@
 #'  value is `FALSE` which means that [att_gt()] will drop
 #'  all units where data is not observed in all periods.
 #'  The advantage of this is that the computations are faster
-#'  (sometimes substantially).  This argument is ignored when
+#'  (sometimes substantially).  A cohort that loses all of its units
+#'  this way is dropped with a warning.  This argument is ignored when
 #'  `panel=FALSE`: repeated cross sections have no panel structure
 #'  to balance.
 #' @param control_group Which units to use as the control group.
@@ -185,7 +186,10 @@
 #'  in the treatment in that time period.  This includes all
 #'  never treated units, but it includes additional units that
 #'  eventually participate in the treatment, but have not
-#'  participated yet.
+#'  participated yet.  If there are no never-treated units (in the
+#'  data, or after the panel is balanced), the last treated cohort
+#'  serves as the comparison group and periods from its treatment
+#'  date (net of `anticipation`) onward are dropped, with a warning.
 #' @param anticipation The number of time periods before participating
 #'  in the treatment where units can anticipate participating in the
 #'  treatment and therefore it can affect their untreated potential outcomes

--- a/R/compute.aggte.R
+++ b/R/compute.aggte.R
@@ -149,6 +149,12 @@ compute.aggte <- function(MP,
   MP$DIDparams$cband <- cband
   dp <- MP$DIDparams
 
+  # nothing to aggregate when every cell is pre-treatment (e.g. the periods from the
+  # last cohort's treatment date onward were dropped for lack of a never-treated group)
+  if (!any(group <= t)) {
+    stop("No post-treatment ATT(g,t) estimates are available to aggregate (all cells have t < g).")
+  }
+
   if (na.rm) {
     notna <- !is.na(att)
     if (!any(notna)) {

--- a/R/compute.att_gt.R
+++ b/R/compute.att_gt.R
@@ -665,6 +665,7 @@ compute.att_gt <- function(dp) {
 
           # If ATT is NaN, replace it with NA, and mark influence function as missing.
           if (is.nan(res$ATT)) {
+            warning(paste0("ATT for (g,t) = (", glist[g], ",", tlist[t + tfac], ") is NaN; setting it to NA"))
             res$ATT <- NA
             if (do_inf) res$att.inf.func <- rep(NA_real_, length(res$att.inf.func))
           }
@@ -931,6 +932,7 @@ compute.att_gt <- function(dp) {
 
           # If ATT is NaN, replace it with NA, and mark influence function as missing
           if (is.nan(res$ATT)) {
+            warning(paste0("ATT for (g,t) = (", glist[g], ",", tlist[t + tfac], ") is NaN; setting it to NA"))
             res$ATT <- NA
             if (do_inf) res$att.inf.func <- rep(NA_real_, length(res$att.inf.func))
           }

--- a/R/compute.att_gt2.R
+++ b/R/compute.att_gt2.R
@@ -418,8 +418,8 @@ run_DRDID <- function(cohort_data, covariates, dp2, g_val = NULL, t_val = NULL,
 #' @keywords internal
 run_att_gt_estimation <- function(g, t, dp2){
 
-  if(dp2$print_details){cat("\n", paste0("Evaluating (g,t) = (",dp2$treated_groups[g],",",dp2$time_periods[t],")"))}
   tfac <- if (dp2$base_period != "universal") 1L else 0L
+  if(dp2$print_details){cat("\n", paste0("Evaluating (g,t) = (",dp2$treated_groups[g],",",dp2$time_periods[t+tfac],")"))}
   # set pret
   # varying base period
   pret <- t
@@ -464,6 +464,7 @@ run_att_gt_estimation <- function(g, t, dp2){
   valid_did_cohort <- any(did_cohort_index == 1) & any(did_cohort_index == 0)
   if(!isTRUE(valid_did_cohort)){
     if(dp2$print_details){cat("\n Skipping (g,t) as no treatment group or control group found")}
+    warning(paste0("No treated or control units available for group ", dp2$treated_groups[g], " in time period ", dp2$time_periods[t+tfac], "; the ATT for this cell is set to NA"))
     return(NULL)
   }
 
@@ -758,6 +759,7 @@ compute.att_gt2 <- function(dp2) {
 
       # Handle NaN ATT: treat as estimation failure
       if (is.nan(att)) {
+        warning(paste0("ATT for (g,t) = (", dp2$treated_groups[g], ",", dp2$time_periods[t+tfac], ") is NaN; setting it to NA"))
         att <- NA
         if (do_inf) {
           if_i <- seq_len(n)

--- a/R/pre_process_did.R
+++ b/R/pre_process_did.R
@@ -114,6 +114,8 @@ pre_process_did <- function(yname,
 
   #  make sure gname is numeric
   if (! (is.numeric(data[, gname])) ) stop("The group variable '", gname, "' must be numeric. Please convert it.")
+  # store as double, as the fast path does
+  if (is.integer(data[, gname])) data[, gname] <- as.numeric(data[, gname])
 
   # gname must be 0 (never-treated) or a positive treatment-timing value.
   # Negative codes are not supported: 0 is reserved for never-treated, so a
@@ -182,6 +184,9 @@ pre_process_did <- function(yname,
   n_diff <- n_orig - nrow(data)
   if (n_diff != 0) {
     warning(paste0("dropped ", n_diff, " rows from original data due to missing or non-finite data"))
+  }
+  if (nrow(data) == 0) {
+    stop("All observations were dropped due to missing data. Check your outcome, group, time, and covariate variables for missing values.")
   }
 
   # weights if null
@@ -257,6 +262,8 @@ pre_process_did <- function(yname,
   #   }
   # }
 
+  # latest_g stays NA while a never-treated group exists (checked again after balancing)
+  latest_g <- NA_real_
   if (!any(glist == 0)) {
     # Compute latest treated cohort once, and the cutoff time
     latest_g <- max(glist, na.rm = TRUE)
@@ -278,6 +285,9 @@ pre_process_did <- function(yname,
     } else {
       # If "notyettreated", we simply drop those periods and leave gnames alone
       data <- data[ data[[ tname ]] < cutoff_t, , drop = FALSE ]
+    }
+    if (nrow(data) == 0) {
+      stop("No periods before the last treated cohort's treatment date (net of anticipation) remain. Check that 'gname' is measured on the same scale as 'tname'.")
     }
 
     # Recompute tlist and glist from the filtered/modified data
@@ -481,6 +491,30 @@ pre_process_did <- function(yname,
 
       n <- nrow(data[ data[,tname]==tlist[1], ])
 
+      # balancing drops whole units: drop cohorts that lost all of theirs, and check
+      # again for a never-treated group (the check above ran before balancing)
+      gone <- setdiff(glist, unique(data[, gname]))
+      if (length(gone) > 0) {
+        warning("Dropped cohort(s) ", paste(gone, collapse = ", "), " while converting to balanced panel; set allow_unbalanced_panel = TRUE to keep them.")
+        glist <- setdiff(glist, gone)
+      }
+      if (!any(data[, gname] == 0) && (is.na(latest_g) || max(data[, gname]) < latest_g)) {
+        latest_g <- max(data[, gname])
+        cutoff_t <- latest_g - anticipation
+        data <- data[ data[[tname]] < cutoff_t, , drop = FALSE ]
+        if (control_group == "nevertreated") {
+          warning("No never-treated group is available after converting to balanced panel (set allow_unbalanced_panel = TRUE to keep the never-treated units). The last treated cohort is being coerced as 'never-treated' units, and data from periods after that is being filtered out (no available comparison groups).")
+          data[data[, gname] == latest_g, gname] <- 0
+        } else {
+          warning("No never-treated group is available after converting to balanced panel (set allow_unbalanced_panel = TRUE to keep the never-treated units). The last treated cohort is used only as a comparison group, and data from periods after that is being filtered out (no available comparison groups).")
+        }
+        tlist <- sort(unique(data[,tname]))
+        glist <- sort(unique(data[,gname]))
+        glist <- glist[glist > 0 & glist > tlist[1] + anticipation]
+        if (control_group != "nevertreated") glist <- glist[glist < latest_g]
+        n <- nrow(data[ data[,tname]==tlist[1], ])
+      }
+
       # slow, repeated check here...
       ## # check that first.treat doesn't change across periods for particular individuals
       ## if (!all(sapply( split(data, data[,idname]), function(df) {
@@ -543,7 +577,13 @@ pre_process_did <- function(yname,
 
   # Check if groups is empty (usually a problem with the way people defined groups)
   if(length(glist)==0){
+    if (!is.na(latest_g)) {
+      stop("No valid groups: with no never-treated group, the last treated cohort (first treated at ", latest_g, ") is used only as a comparison group and no other treated cohort remains.")
+    }
     stop("No valid groups. The variable in 'gname' should be expressed as the time a unit is first treated (0 if never-treated).")
+  }
+  if (length(tlist) < 2) {
+    stop("Only one time period remains after dropping periods from the last treated cohort's treatment date onward.")
   }
 
   # if there are only two time periods, then uniform confidence

--- a/R/pre_process_did2.R
+++ b/R/pre_process_did2.R
@@ -179,6 +179,9 @@ did_standardization <- function(data, args){
   if (n_diff != 0) {
     warning(paste0("dropped ", n_diff, " rows from original data due to missing or non-finite data"))
   }
+  if (n_new == 0) {
+    stop("All observations were dropped due to missing data. Check your outcome, group, time, and covariate variables for missing values.")
+  }
 
   # Set weights
   if (is.null(args$weightsname)) weights <- rep(1, n_new) else weights <- data[[args$weightsname]]
@@ -257,6 +260,8 @@ did_standardization <- function(data, args){
   #   }
   # }
 
+  # latest_g stays NA while a never-treated group exists (checked again after balancing)
+  latest_g <- NA_real_
   if (!(Inf %in% glist)) {
     # Compute latest treated cohort once, and the cutoff time
     latest_g <- max(glist[is.finite(glist)], na.rm = TRUE)
@@ -279,6 +284,9 @@ did_standardization <- function(data, args){
     } else {
       # 3. If not "nevertreated", we simply drop those periods and leave gnames alone
       data <- data[get(args$tname) < cutoff_t]
+    }
+    if (nrow(data) == 0) {
+      stop("No periods before the last treated cohort's treatment date (net of anticipation) remain. Check that 'gname' is measured on the same scale as 'tname'.")
     }
 
     # Recompute tlist and glist from the filtered/modified data
@@ -406,6 +414,30 @@ did_standardization <- function(data, args){
 
       n <- sum(data[[args$tname]] == tlist[1])
 
+      # balancing drops whole units: drop cohorts that lost all of theirs, and check
+      # again for a never-treated group (the check above ran before balancing)
+      gone <- setdiff(glist, unique(data[[args$gname]]))
+      if (length(gone) > 0) {
+        warning("Dropped cohort(s) ", paste(gone, collapse = ", "), " while converting to balanced panel; set allow_unbalanced_panel = TRUE to keep them.")
+        glist <- setdiff(glist, gone)
+      }
+      if (!any(is.infinite(data[[args$gname]])) && (is.na(latest_g) || max(data[[args$gname]]) < latest_g)) {
+        latest_g <- max(data[[args$gname]])
+        cutoff_t <- latest_g - args$anticipation
+        data <- data[get(args$tname) < cutoff_t]
+        if (args$control_group == "nevertreated") {
+          warning("No never-treated group is available after converting to balanced panel (set allow_unbalanced_panel = TRUE to keep the never-treated units). The last treated cohort is being coerced as 'never-treated' units, and data from periods after that is being filtered out (no available comparison groups).")
+          data[get(args$gname) == latest_g, (args$gname) := Inf]
+        } else {
+          warning("No never-treated group is available after converting to balanced panel (set allow_unbalanced_panel = TRUE to keep the never-treated units). The last treated cohort is used only as a comparison group, and data from periods after that is being filtered out (no available comparison groups).")
+        }
+        tlist <- sort(unique(data[[args$tname]]))
+        glist <- sort(unique(data[[args$gname]]))
+        glist <- glist[glist != Inf & glist > tlist[1] + args$anticipation]
+        if (args$control_group != "nevertreated") glist <- glist[glist < latest_g]
+        n <- sum(data[[args$tname]] == tlist[1])
+      }
+
       # Note: treatment irreversibility was already checked in validate_args()
     }
   }
@@ -437,7 +469,13 @@ did_standardization <- function(data, args){
 
   # Check if groups is empty (usually a problem with the way people defined groups)
   if(length(glist)==0){
+    if (!is.na(latest_g)) {
+      stop("No valid groups: with no never-treated group, the last treated cohort (first treated at ", latest_g, ") is used only as a comparison group and no other treated cohort remains.")
+    }
     stop("No valid groups. The variable in 'gname' should be expressed as the time a unit is first treated (0 if never-treated).")
+  }
+  if (length(tlist) < 2) {
+    stop("Only one time period remains after dropping periods from the last treated cohort's treatment date onward.")
   }
 
   # if there are only two time periods, then uniform confidence

--- a/man/DIDparams.Rd
+++ b/man/DIDparams.Rd
@@ -80,7 +80,10 @@ is set to the group of units that have not yet participated
 in the treatment in that time period.  This includes all
 never treated units, but it includes additional units that
 eventually participate in the treatment, but have not
-participated yet.}
+participated yet.  If there are no never-treated units (in the
+data, or after the panel is balanced), the last treated cohort
+serves as the comparison group and periods from its treatment
+date (net of \code{anticipation}) onward are dropped, with a warning.}
 
 \item{anticipation}{The number of time periods before participating
 in the treatment where units can anticipate participating in the

--- a/man/att_gt.Rd
+++ b/man/att_gt.Rd
@@ -79,7 +79,8 @@ as repeated cross sections.}
 value is \code{FALSE} which means that \code{\link[=att_gt]{att_gt()}} will drop
 all units where data is not observed in all periods.
 The advantage of this is that the computations are faster
-(sometimes substantially).  This argument is ignored when
+(sometimes substantially).  A cohort that loses all of its units
+this way is dropped with a warning.  This argument is ignored when
 \code{panel=FALSE}: repeated cross sections have no panel structure
 to balance.}
 
@@ -93,7 +94,10 @@ is set to the group of units that have not yet participated
 in the treatment in that time period.  This includes all
 never treated units, but it includes additional units that
 eventually participate in the treatment, but have not
-participated yet.}
+participated yet.  If there are no never-treated units (in the
+data, or after the panel is balanced), the last treated cohort
+serves as the comparison group and periods from its treatment
+date (net of \code{anticipation}) onward are dropped, with a warning.}
 
 \item{anticipation}{The number of time periods before participating
 in the treatment where units can anticipate participating in the

--- a/man/conditional_did_pretest.Rd
+++ b/man/conditional_did_pretest.Rd
@@ -73,7 +73,8 @@ as repeated cross sections.}
 value is \code{FALSE} which means that \code{\link[=att_gt]{att_gt()}} will drop
 all units where data is not observed in all periods.
 The advantage of this is that the computations are faster
-(sometimes substantially).  This argument is ignored when
+(sometimes substantially).  A cohort that loses all of its units
+this way is dropped with a warning.  This argument is ignored when
 \code{panel=FALSE}: repeated cross sections have no panel structure
 to balance.}
 
@@ -87,7 +88,10 @@ is set to the group of units that have not yet participated
 in the treatment in that time period.  This includes all
 never treated units, but it includes additional units that
 eventually participate in the treatment, but have not
-participated yet.}
+participated yet.  If there are no never-treated units (in the
+data, or after the panel is balanced), the last treated cohort
+serves as the comparison group and periods from its treatment
+date (net of \code{anticipation}) onward are dropped, with a warning.}
 
 \item{weightsname}{The name of the column containing the sampling weights.
 If not set, all observations have same weight.}

--- a/man/pre_process_did.Rd
+++ b/man/pre_process_did.Rd
@@ -78,7 +78,8 @@ as repeated cross sections.}
 value is \code{FALSE} which means that \code{\link[=att_gt]{att_gt()}} will drop
 all units where data is not observed in all periods.
 The advantage of this is that the computations are faster
-(sometimes substantially).  This argument is ignored when
+(sometimes substantially).  A cohort that loses all of its units
+this way is dropped with a warning.  This argument is ignored when
 \code{panel=FALSE}: repeated cross sections have no panel structure
 to balance.}
 
@@ -92,7 +93,10 @@ is set to the group of units that have not yet participated
 in the treatment in that time period.  This includes all
 never treated units, but it includes additional units that
 eventually participate in the treatment, but have not
-participated yet.}
+participated yet.  If there are no never-treated units (in the
+data, or after the panel is balanced), the last treated cohort
+serves as the comparison group and periods from its treatment
+date (net of \code{anticipation}) onward are dropped, with a warning.}
 
 \item{anticipation}{The number of time periods before participating
 in the treatment where units can anticipate participating in the

--- a/man/pre_process_did2.Rd
+++ b/man/pre_process_did2.Rd
@@ -78,7 +78,8 @@ as repeated cross sections.}
 value is \code{FALSE} which means that \code{\link[=att_gt]{att_gt()}} will drop
 all units where data is not observed in all periods.
 The advantage of this is that the computations are faster
-(sometimes substantially).  This argument is ignored when
+(sometimes substantially).  A cohort that loses all of its units
+this way is dropped with a warning.  This argument is ignored when
 \code{panel=FALSE}: repeated cross sections have no panel structure
 to balance.}
 
@@ -92,7 +93,10 @@ is set to the group of units that have not yet participated
 in the treatment in that time period.  This includes all
 never treated units, but it includes additional units that
 eventually participate in the treatment, but have not
-participated yet.}
+participated yet.  If there are no never-treated units (in the
+data, or after the panel is balanced), the last treated cohort
+serves as the comparison group and periods from its treatment
+date (net of \code{anticipation}) onward are dropped, with a warning.}
 
 \item{anticipation}{The number of time periods before participating
 in the treatment where units can anticipate participating in the

--- a/man/trimmer.Rd
+++ b/man/trimmer.Rd
@@ -59,7 +59,10 @@ is set to the group of units that have not yet participated
 in the treatment in that time period.  This includes all
 never treated units, but it includes additional units that
 eventually participate in the treatment, but have not
-participated yet.}
+participated yet.  If there are no never-treated units (in the
+data, or after the panel is balanced), the last treated cohort
+serves as the comparison group and periods from its treatment
+date (net of \code{anticipation}) onward are dropped, with a warning.}
 
 \item{threshold}{the cutoff for which observations are flagged as
 likely violators of the support condition.}

--- a/tests/testthat/test-nevertreated-balanced-panel.R
+++ b/tests/testthat/test-nevertreated-balanced-panel.R
@@ -1,0 +1,174 @@
+# Balancing the panel drops units whole. att_gt() checked for a never-treated group
+# before balancing, so when balancing removed every never-treated unit (e.g. a
+# covariate missing in one period for all of them) every ATT(g,t) came back NA --
+# silently under faster_mode = TRUE, as "overlap condition violated" under
+# faster_mode = FALSE. A treated cohort removed the same way crashed the fast path.
+
+make_panel <- function(cohorts = c(0, 3, 4), n_per = 30L, periods = 1:5, seed = 1) {
+  set.seed(seed)
+  ids <- seq_len(n_per * length(cohorts))
+  d <- data.frame(id = rep(ids, each = length(periods)),
+                  time = rep(periods, times = length(ids)),
+                  g = rep(rep(cohorts, each = n_per), each = length(periods)))
+  d$x1 <- rnorm(nrow(d))
+  d$y <- 1 + d$x1 + 0.3 * d$time + (d$g > 0 & d$time >= d$g) + rnorm(nrow(d))
+  d
+}
+# x1 missing in one period for every unit of cohort(s) gsel
+kill_x1 <- function(d, gsel, tsel = 2) { d$x1[d$g %in% gsel & d$time %in% tsel] <- NA; d }
+
+fit_gt <- function(d, ...) {
+  att_gt(yname = "y", tname = "time", idname = "id", gname = "g", xformla = ~x1,
+         data = d, bstrap = FALSE, cband = FALSE, ...)
+}
+quiet_fit <- function(d, ...) suppressWarnings(suppressMessages(fit_gt(d, ...)))
+expect_same_fit <- function(fit, ref) {
+  expect_identical(fit$group, ref$group); expect_identical(fit$t, ref$t); expect_identical(fit$n, ref$n)
+  expect_equal(fit$att, ref$att, tolerance = 1e-10); expect_equal(fit$se, ref$se, tolerance = 1e-10)
+}
+RECHECK <- "No never-treated group is available after converting to balanced panel"
+
+test_that("never-treated group removed by balancing is re-checked", {
+  d <- kill_x1(make_panel(), gsel = 0)
+  d_bal <- d[d$g != 0, ]   # what balancing leaves behind
+  for (cg in c("nevertreated", "notyettreated")) {
+    msgs <- list()
+    for (fm in c(TRUE, FALSE)) {
+      w <- capture_warnings(suppressMessages(fit <- fit_gt(d, control_group = cg, faster_mode = fm)))
+      msgs[[as.character(fm)]] <- grep(RECHECK, w, fixed = TRUE, value = TRUE)
+      expect_length(msgs[[as.character(fm)]], 1L)
+      expect_false(any(grepl("overlap", w)))
+      expect_false(anyNA(fit$att))
+      expect_false(4 %in% fit$group)   # last cohort is the comparison group only
+      expect_same_fit(fit, quiet_fit(d_bal, control_group = cg, faster_mode = fm))
+    }
+    expect_identical(msgs[["TRUE"]], msgs[["FALSE"]])
+    slow <- quiet_fit(d, control_group = cg, faster_mode = FALSE)
+    fast <- quiet_fit(d, control_group = cg, faster_mode = TRUE)
+    expect_same_fit(slow, fast)
+    expect_length(fast$att, 2L)
+  }
+})
+
+test_that("re-check honors anticipation", {
+  d <- kill_x1(make_panel(), gsel = 0)
+  for (cg in c("nevertreated", "notyettreated")) for (fm in c(TRUE, FALSE)) {
+    expect_warning(fit <- suppressMessages(fit_gt(d, control_group = cg, anticipation = 1, faster_mode = fm)), RECHECK, fixed = TRUE)
+    expect_identical(fit$t, 2)   # cutoff 4 - 1 = 3 leaves periods 1-2
+    expect_same_fit(fit, quiet_fit(d[d$g != 0, ], control_group = cg, anticipation = 1, faster_mode = fm))
+  }
+})
+
+test_that("re-check also covers the comparison cohort coerced from the raw data", {
+  # no never-treated group: cohort 5 becomes the comparison group, then balancing removes it
+  d <- kill_x1(make_panel(cohorts = c(3, 4, 5)), gsel = 5)
+  for (cg in c("nevertreated", "notyettreated")) for (fm in c(TRUE, FALSE)) {
+    w <- capture_warnings(suppressMessages(fit <- fit_gt(d, control_group = cg, faster_mode = fm)))
+    expect_length(grep(RECHECK, w, fixed = TRUE), 1L)
+    expect_false(anyNA(fit$att))
+    expect_same_fit(fit, quiet_fit(d[d$g != 5, ], control_group = cg, faster_mode = fm))
+  }
+})
+
+test_that("a treated cohort removed by balancing is dropped with a warning, not an internal error", {
+  cases <- list(list(d = make_panel(cohorts = c(0, 3, 4, 5)), kill = 4),
+                list(d = make_panel(cohorts = c(0, 3, 4, 5)), kill = 5),
+                list(d = make_panel(cohorts = c(3, 4, 5, 6), periods = 1:7), kill = 4))
+  for (cs in cases) for (cg in c("nevertreated", "notyettreated")) for (fm in c(TRUE, FALSE)) {
+    d <- kill_x1(cs$d, gsel = cs$kill)
+    w <- capture_warnings(suppressMessages(fit <- fit_gt(d, control_group = cg, faster_mode = fm)))
+    expect_length(grep(paste0("Dropped cohort(s) ", cs$kill, " while converting to balanced panel"), w, fixed = TRUE), 1L)
+    expect_false(any(grepl("Internal error", w)))
+    expect_false(cs$kill %in% fit$group)
+    expect_false(anyNA(fit$att))
+    expect_same_fit(fit, quiet_fit(cs$d[cs$d$g != cs$kill, ], control_group = cg, faster_mode = fm))
+  }
+})
+
+test_that("no re-check when never-treated units survive balancing or the panel is left unbalanced", {
+  d <- make_panel()
+  clean <- quiet_fit(d)
+  d_half <- d; d_half$x1[d_half$g == 0 & d_half$time == 2 & d_half$id <= 15] <- NA
+  for (fm in c(TRUE, FALSE)) {
+    w <- capture_warnings(suppressMessages(fit <- fit_gt(d_half, faster_mode = fm)))
+    expect_false(any(grepl("never-treated|Dropped cohort", w)))
+    expect_identical(fit$group, clean$group); expect_identical(fit$t, clean$t); expect_identical(fit$n, 75L)
+    w <- capture_warnings(suppressMessages(fit <- fit_gt(kill_x1(d, 0), allow_unbalanced_panel = TRUE, faster_mode = fm)))
+    expect_false(any(grepl("never-treated|Dropped cohort", w)))
+    late4 <- fit$att[fit$group == 4 & fit$t %in% c(4, 5)]
+    expect_length(late4, 2L); expect_false(anyNA(late4))
+  }
+})
+
+test_that("'notyettreated' without a never-treated group in the raw data stays silent", {
+  d <- make_panel(cohorts = c(3, 4))
+  for (fm in c(TRUE, FALSE)) {
+    w <- capture_warnings(suppressMessages(fit <- fit_gt(d, control_group = "notyettreated", faster_mode = fm)))
+    expect_false(any(grepl("never-treated", w)))
+    expect_false(4 %in% fit$group)
+  }
+})
+
+test_that("nothing left to estimate gives an error that names the cause, identically in both modes", {
+  cases <- list(
+    list(d = kill_x1(make_panel(cohorts = c(0, 3)), gsel = 0), extra = list(),
+         msg = "the last treated cohort (first treated at 3) is used only as a comparison group and no other treated cohort remains"),
+    list(d = make_panel(cohorts = 1), extra = list(), msg = "No periods before the last treated cohort's treatment date"),
+    list(d = make_panel(cohorts = 1, periods = 2010:2014), extra = list(), msg = "same scale as 'tname'"),
+    list(d = kill_x1(make_panel(cohorts = c(0, 3, 5), periods = c(1, 4, 7)), gsel = 0, tsel = 4), extra = list(anticipation = 1),
+         msg = "Only one time period remains"),
+    list(d = kill_x1(make_panel(), gsel = c(3, 4)), extra = list(), msg = "No valid groups")
+  )
+  for (cs in cases) for (cg in c("nevertreated", "notyettreated")) {
+    e <- lapply(c(TRUE, FALSE), function(fm)
+      tryCatch(do.call(quiet_fit, c(list(cs$d, control_group = cg, faster_mode = fm), cs$extra)), error = function(e) conditionMessage(e)))
+    expect_type(e[[1]], "character")
+    expect_match(e[[1]], cs$msg, fixed = TRUE)
+    expect_identical(e[[1]], e[[2]])
+  }
+})
+
+test_that("a sample emptied by the missing-data drop stops with the missing-data message", {
+  d <- make_panel(); d$y <- NA_real_
+  for (fm in c(TRUE, FALSE)) {
+    w <- character()
+    e <- tryCatch(withCallingHandlers(suppressMessages(fit_gt(d, faster_mode = fm)),
+                                      warning = function(w0) { w <<- c(w, conditionMessage(w0)); invokeRestart("muffleWarning") }),
+                  error = function(e) conditionMessage(e))
+    expect_match(e, "All observations were dropped due to missing data", fixed = TRUE)
+    expect_false(any(grepl("-Inf|no non-missing arguments", c(e, w))))
+  }
+})
+
+test_that("a NaN 2x2 estimate is announced (both modes)", {
+  d <- make_panel(); d$w0 <- ifelse(d$g == 4, 0, 1)   # cohort 4 has no effective units
+  for (fm in c(TRUE, FALSE)) {
+    w <- capture_warnings(suppressMessages(fit <- fit_gt(d, weightsname = "w0", faster_mode = fm)))
+    na_cells <- which(is.na(fit$att))
+    expect_identical(fit$group[na_cells], rep(4, 4))
+    for (i in na_cells) expect_true(any(grepl(paste0("(g,t) = (4,", fit$t[i], ") is NaN"), w, fixed = TRUE)))
+  }
+})
+
+test_that("faster_mode = TRUE names a cell with no control units instead of returning NA silently", {
+  set.seed(3)
+  d <- expand.grid(rep = 1:40, time = 1:5, g = c(0, 3))
+  d$y <- rnorm(nrow(d)) + 0.2 * d$time + (d$g > 0 & d$time >= d$g)
+  d <- d[!(d$g == 0 & d$time %in% 2:4), ]   # never-treated observed only in periods 1 and 5
+  d$id <- seq_len(nrow(d))
+  w <- capture_warnings(suppressMessages(
+    fit <- att_gt(yname = "y", tname = "time", idname = "id", gname = "g", data = d, panel = FALSE, bstrap = FALSE, cband = FALSE)
+  ))
+  expect_true(all(is.na(fit$att)))
+  for (tt in c(3, 4)) expect_true(any(grepl(paste0("No treated or control units available for group 3 in time period ", tt), w, fixed = TRUE)))
+})
+
+test_that("aggte() explains an object with no post-treatment cells", {
+  d <- make_panel(cohorts = c(4, 6), periods = 1:6)   # anticipation 2 drops periods >= 4
+  for (fm in c(TRUE, FALSE)) {
+    fit <- quiet_fit(d, anticipation = 2, faster_mode = fm)
+    expect_true(all(fit$t < fit$group))
+    for (ty in c("simple", "dynamic", "group", "calendar"))
+      expect_error(suppressWarnings(aggte(fit, type = ty)), "No post-treatment ATT(g,t) estimates are available", fixed = TRUE)
+  }
+})


### PR DESCRIPTION
Supersedes #274 (same fixes, minimal diff in the existing style).

## Bug fixes

- `att_gt()` decided whether a never-treated group exists **before** coercing the data to a balanced panel. Balancing drops units whole, so a covariate missing in one period for every never-treated unit removed the whole group after the check had passed: every ATT(g,t) came back `NA` — silently under `faster_mode = TRUE`, as "overlap condition violated" under `faster_mode = FALSE`. Both pre-processors now check again after balancing and apply the same rule as for data without a never-treated group (last treated cohort used as the comparison group, later periods dropped), with a warning; the estimates equal those from the balanced sample (tests, both paths, 1e-10). Reported from the Stata `csdid` parity work.
- A treated cohort that loses all of its units in balancing is now dropped with a warning; `faster_mode = TRUE` stopped with "Internal error: treated group g not found in cohort_vec" and `faster_mode = FALSE` returned `NA` for all of its cells.
- A (g,t) cell with no treated or control units (`faster_mode = TRUE`) or a `NaN` estimate (both paths) now warns instead of becoming `NA` silently; `faster_mode = FALSE` stores an integer `gname` as double, as the fast path does.
- Clearer errors when nothing can be estimated (no treated cohort left once the last cohort is the comparison group; no period before its treatment date; a single period left; a sample emptied by the missing-data drop), and `aggte()` says so when there is no post-treatment cell.

Under `control_group = "notyettreated"` the last cohort's pre-treatment cells are no longer computed in the balancing case (it is a comparison group only, as in the raw-data rule). The routine `notyettreated` case without a never-treated group stays silent.

## Docs / tests

`?att_gt` (`control_group`, `allow_unbalanced_panel`), `NEWS.md` 2.5.1.902, `tests/testthat/test-nevertreated-balanced-panel.R`. Differential over a 13-shape family × 2 paths × 2 control groups against master: only the affected shapes change.
